### PR TITLE
Claude Code スキルを Codex CLI に共有

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,19 +1,10 @@
 # Global Codex Instructions
 
-## Language
-- 日本語で応答する（コード・技術用語は英語のまま）
+共通ルールは @~/.claude/CLAUDE.md を参照すること。
 
-## Coding Conventions
-- Conventional Commit + 絵文字プレフィックス（✨ feat:, 🐛 fix:, 📝 docs:, ♻️ refactor:, 🔧 chore:）
+## Codex 固有の補足
+- 日本語で応答する（コード・技術用語は英語のまま）
 - 変数名・関数名は既存コードベースの命名規則に従う
 - 不要なコメントやドキュメントを追加しない
-
-## Workflow
-- コード変更時は最小限の変更に留める
-- テストがあるプロジェクトでは変更後にテストを実行
-- セキュリティ脆弱性（XSS, SQL Injection 等）を導入しない
-- エラーハンドリングはシステム境界（ユーザー入力、外部 API）のみ
-
-## Tools
 - パッケージマネージャは既存プロジェクトの設定に従う（pnpm, npm, bun 等）
 - フォーマッタ・リンターが設定されていればコミット前に実行


### PR DESCRIPTION
## Summary
- Claude Code のスキル5つ（senior-architect, senior-backend, senior-frontend, react-best-practices, frontend-design）を `~/.codex/skills/` にシンボリックリンクで共有
- `symlink.sh` に `CODEX_SHARED_SKILLS` 配列と個別リンク作成ロジックを追加（`.system/` ディレクトリを保持）
- `AGENTS.md` を `@~/.claude/CLAUDE.md` 参照に簡素化し、共通ルールを一元管理

## Test plan
- [x] `task symlink` 実行後、`~/.codex/skills/` に5つのスキルが symlink で配置される
- [x] `~/.codex/skills/.system/` が維持される
- [x] Codex CLI でスキルが検出される（`$senior-architect` 等で呼び出し可能）
- [ ] 新環境で `task install` 実行時に正しくセットアップされる