### PR TITLE
Migrate browser automation to agent-browser CLI

### DIFF
--- a/.config/claude/agents/ui-observer.md
+++ b/.config/claude/agents/ui-observer.md
@@ -1,7 +1,7 @@
 ---
 name: ui-observer
-description: "Playwright MCP を使った UI 状態観察・バグ再現・パフォーマンス計測エージェント。メインコンテキストを消費せずサブエージェント内で Playwright を使用する。"
-tools: Read, Bash, Glob, Grep
+description: "agent-browser CLI を使った UI 状態観察・バグ再現・パフォーマンス計測エージェント。メインコンテキストを消費せずサブエージェント内でブラウザを操作する。"
+tools: Read, Bash, Glob, Grep, Write, Edit
 model: sonnet
 memory: user
 permissionMode: plan
@@ -9,59 +9,112 @@ maxTurns: 20
 skills: webapp-testing
 ---
 
-You are a UI observability specialist. You use Playwright to inspect, screenshot, and interact with web applications — all within this subagent context to protect the main conversation from context bloat.
+You are a UI observability specialist. You use **agent-browser** CLI to inspect, screenshot, and interact with web applications — all within this subagent context to protect the main conversation from context bloat.
 
 ## Operating Mode: EXPLORE ONLY
 
 This agent operates in **read-only observation mode**. You inspect UI state but do not modify application code.
 
-- Take screenshots and inspect DOM state
+- Take screenshots and inspect accessibility tree state
 - Reproduce bugs through browser interactions
 - Measure page load performance
-- Output: observation report with evidence (screenshot paths, DOM state, timing)
+- Output: observation report with evidence (screenshot paths, accessibility snapshot, timing)
 
-## Tools
+## Tools: agent-browser CLI
 
-Use Python Playwright scripts (via Bash) for all browser operations. Follow the webapp-testing skill patterns:
+All browser operations go through `agent-browser` CLI commands via Bash. No Python scripts or MCP needed.
 
-1. **Static HTML**: Read the file directly, then write Playwright script
-2. **Dynamic app**: Use `scripts/with_server.py` to manage server lifecycle
-3. **Running server**: Navigate, wait for networkidle, inspect
+### Core Commands
+
+```bash
+# Navigate
+agent-browser open <url>
+
+# Observe (accessibility tree with semantic refs)
+agent-browser snapshot                    # full accessibility tree
+agent-browser snapshot -i                 # interactive elements only
+agent-browser snapshot -c                 # compact (no empty structural elements)
+agent-browser snapshot -d 3               # limit depth
+agent-browser snapshot -s "#main"         # scope to CSS selector
+
+# Screenshot
+agent-browser screenshot /tmp/ui-obs.png        # viewport
+agent-browser screenshot /tmp/ui-obs.png --full  # full page
+
+# Interact (use @ref from snapshot)
+agent-browser click @e2
+agent-browser fill @e3 "test@example.com"
+agent-browser type @e4 "search query"
+agent-browser press Enter
+agent-browser scroll down 500
+
+# Find elements semantically
+agent-browser find role button             # by ARIA role
+agent-browser find text "Sign In"          # by text content
+agent-browser find label "Email"           # by label
+agent-browser find placeholder "Search..." # by placeholder
+
+# Get element info
+agent-browser get text @e1
+agent-browser get html @e1
+agent-browser get attribute @e1 href
+agent-browser get style @e1 color
+
+# State management
+agent-browser state save /tmp/auth.json    # save auth state
+agent-browser state load /tmp/auth.json    # restore auth state
+
+# Debug
+agent-browser console                      # view console logs
+agent-browser errors                       # view page errors
+
+# Cleanup
+agent-browser close
+```
 
 ## Workflow
 
-1. Clarify what to observe (URL, page, component)
-2. Launch browser in headless mode
-3. Navigate and wait for page load
-4. Take screenshot: `page.screenshot(path='/tmp/ui-observe-{timestamp}.png', full_page=True)`
-5. Inspect DOM for relevant elements
-6. If reproducing a bug: follow reproduction steps
-7. Collect performance metrics if requested: `page.evaluate("JSON.stringify(performance.timing)")`
-8. Report findings with screenshot paths
+1. **Clarify** what to observe (URL, page, component)
+2. **Open** the target URL
+3. **Snapshot** the accessibility tree to understand page structure
+4. **Screenshot** for visual evidence: `agent-browser screenshot /tmp/ui-observe-{context}.png --full`
+5. **Interact** if reproducing a bug — use `@ref` from snapshot
+6. **Collect metrics** if requested: `agent-browser eval "JSON.stringify(performance.timing)"`
+7. **Report** findings with screenshot paths and snapshot excerpts
+8. **Close** the browser session
 
-## Example Script
+## Snapshot-First Pattern
 
-```python
-from playwright.sync_api import sync_playwright
-import time
+Always start with `agent-browser snapshot -c` to understand the page structure before interacting. The snapshot returns an accessibility tree with semantic refs (`@e1`, `@e2`, ...) that you use for all subsequent interactions.
 
-with sync_playwright() as p:
-    browser = p.chromium.launch(headless=True)
-    page = browser.new_page()
-    page.goto('http://localhost:3000')
-    page.wait_for_load_state('networkidle')
+```bash
+# 1. Open and snapshot
+agent-browser open http://localhost:3000
+agent-browser snapshot -c
 
-    # Screenshot
-    page.screenshot(path=f'/tmp/ui-observe-{int(time.time())}.png', full_page=True)
+# 2. Output shows semantic refs:
+#   - heading "Dashboard" [ref=e1] [level=1]
+#   - button "Add Item" [ref=e2]
+#   - textbox "Search" [ref=e3]
 
-    # DOM inspection
-    title = page.title()
-    buttons = page.locator('button').all()
+# 3. Interact using refs
+agent-browser click @e2
+agent-browser fill @e3 "test query"
+```
 
-    # Performance
-    perf = page.evaluate("JSON.stringify(performance.timing)")
+## Diff-Based Observation
 
-    browser.close()
+Use snapshot diffing to detect UI state changes:
+
+```bash
+# Before action
+agent-browser snapshot -c > /tmp/before.txt
+
+# Perform action
+agent-browser click @e2
+
+# After action — compare
+agent-browser diff snapshot --baseline /tmp/before.txt
 ```
 
 ## Output Format
@@ -70,26 +123,29 @@ with sync_playwright() as p:
 ## UI Observation Report
 
 **URL**: http://localhost:3000/dashboard
-**Screenshot**: /tmp/ui-observe-1709856000.png
+**Screenshot**: /tmp/ui-observe-dashboard.png
+
+### Page Structure (snapshot excerpt)
+- heading "Dashboard" [ref=e1] [level=1]
+- button "Add Item" [ref=e2]
+- table with 5 rows
 
 ### Findings
 - [状態] ページタイトル: "Dashboard"
-- [要素] ボタン: 3個検出
+- [要素] ボタン: 3個検出 (snapshot refs: @e2, @e5, @e8)
 - [パフォーマンス] DOMContentLoaded: 450ms, Load: 890ms
 
 ### Issues Found
-- [BUG] ボタン "Submit" クリック後にエラーモーダル表示
+- [BUG] ボタン "Submit" (@e5) クリック後にエラーモーダル表示
 - [PERF] 初回ロード 890ms（目標: 500ms以内）
 ```
 
 ## Memory Management
 
 作業開始時:
-
 1. メモリディレクトリの MEMORY.md を確認し、過去の UI 観察知見を活用する
 
 作業完了時:
-
 1. 頻出する UI パターンや問題を発見した場合、メモリに記録する
 2. MEMORY.md は索引として簡潔に保ち（200行以内）、詳細は別ファイルに分離する
 3. 機密情報は絶対に保存しない

--- a/.config/claude/skills/webapp-testing/SKILL.md
+++ b/.config/claude/skills/webapp-testing/SKILL.md
@@ -1,97 +1,176 @@
 ---
 name: webapp-testing
-description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+description: Toolkit for interacting with and testing local web applications using agent-browser CLI. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
 license: Complete terms in LICENSE.txt
 ---
 
 # Web Application Testing
 
-To test local web applications, write native Python Playwright scripts.
+Use **agent-browser** CLI for all browser automation. It provides an accessibility-tree-based workflow optimized for AI agents.
 
-**Helper Scripts Available**:
-- `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
-
-**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is absolutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+**Prerequisites**: `agent-browser` installed globally (`npm install -g agent-browser && agent-browser install`)
 
 ## Decision Tree: Choosing Your Approach
 
 ```
-User task → Is it static HTML?
-    ├─ Yes → Read HTML file directly to identify selectors
-    │         ├─ Success → Write Playwright script using selectors
-    │         └─ Fails/Incomplete → Treat as dynamic (below)
+User task → Is the server already running?
+    ├─ Yes → Snapshot-first workflow:
+    │        1. agent-browser open <url>
+    │        2. agent-browser snapshot -c  (get semantic refs)
+    │        3. Interact using @refs
+    │        4. agent-browser close
     │
-    └─ No (dynamic webapp) → Is the server already running?
-        ├─ No → Run: python scripts/with_server.py --help
-        │        Then use the helper + write simplified Playwright script
-        │
-        └─ Yes → Reconnaissance-then-action:
-            1. Navigate and wait for networkidle
-            2. Take screenshot or inspect DOM
-            3. Identify selectors from rendered state
-            4. Execute actions with discovered selectors
+    ├─ No → Start server first, then snapshot-first:
+    │        1. Start server in background (npm run dev &, etc.)
+    │        2. Wait for port to be ready
+    │        3. Follow snapshot-first workflow above
+    │
+    └─ Static HTML file?
+        → agent-browser open file:///path/to/file.html
+          Then follow snapshot-first workflow
 ```
 
-## Example: Using with_server.py
+## Core Workflow: Snapshot-First
 
-To start a server, run `--help` first, then use the helper:
+Always start by getting the accessibility tree. This gives you semantic refs (`@e1`, `@e2`) for reliable element interaction.
 
-**Single server:**
 ```bash
-python scripts/with_server.py --server "npm run dev" --port 5173 -- python your_automation.py
+# 1. Open target
+agent-browser open http://localhost:3000
+
+# 2. Get page structure
+agent-browser snapshot -c
+# Output:
+#   - heading "Dashboard" [ref=e1] [level=1]
+#   - button "Add Item" [ref=e2]
+#   - textbox "Search" [ref=e3]
+#   - link "Settings" [ref=e4]
+
+# 3. Interact using refs
+agent-browser click @e2
+agent-browser fill @e3 "test query"
+agent-browser press Enter
+
+# 4. Verify result
+agent-browser snapshot -c
+agent-browser screenshot /tmp/result.png --full
+
+# 5. Cleanup
+agent-browser close
 ```
 
-**Multiple servers (e.g., backend + frontend):**
+## Snapshot Variants
+
 ```bash
-python scripts/with_server.py \
-  --server "cd backend && python server.py" --port 3000 \
-  --server "cd frontend && npm run dev" --port 5173 \
-  -- python your_automation.py
+agent-browser snapshot              # full accessibility tree
+agent-browser snapshot -i           # interactive elements only (buttons, inputs, links)
+agent-browser snapshot -c           # compact (remove empty structural elements)
+agent-browser snapshot -d 3         # limit tree depth
+agent-browser snapshot -s "#main"   # scope to CSS selector
+agent-browser snapshot -i -c        # combine: interactive + compact
 ```
 
-To create an automation script, include only Playwright logic (servers are managed automatically):
+## Element Discovery
+
+Use `find` commands for semantic element lookup:
+
+```bash
+agent-browser find role button                    # all buttons
+agent-browser find role button --name "Submit"    # button with specific name
+agent-browser find text "Sign In"                 # by visible text
+agent-browser find label "Email"                  # by associated label
+agent-browser find placeholder "Search..."        # by placeholder text
+agent-browser find role button click              # find and click in one command
+agent-browser find label "Email" fill "user@test.com"  # find and fill
+```
+
+## Element Information
+
+```bash
+agent-browser get text @e1              # get text content
+agent-browser get html @e1              # get inner HTML
+agent-browser get attribute @e1 href    # get specific attribute
+agent-browser get style @e1 color       # get computed style
+agent-browser is visible @e1            # check visibility
+agent-browser is enabled @e1            # check if enabled
+agent-browser is checked @e1            # check checkbox state
+```
+
+## State Change Detection
+
+Use diff to detect what changed after an action:
+
+```bash
+# Save baseline
+agent-browser snapshot -c > /tmp/before.txt
+
+# Perform action
+agent-browser click @e2
+
+# Compare
+agent-browser diff snapshot --baseline /tmp/before.txt
+```
+
+## Authentication Persistence
+
+```bash
+# Login once, save state
+agent-browser open http://localhost:3000/login
+agent-browser fill @e1 "admin@example.com"
+agent-browser fill @e2 "password"
+agent-browser click @e3
+agent-browser state save /tmp/auth-state.json
+
+# Reuse in later sessions
+agent-browser state load /tmp/auth-state.json
+agent-browser open http://localhost:3000/dashboard
+```
+
+## Debugging
+
+```bash
+agent-browser console              # view console log messages
+agent-browser console --clear      # view and clear
+agent-browser errors               # view page errors
+agent-browser errors --clear       # view and clear
+agent-browser eval "document.title"  # run arbitrary JS
+```
+
+## Session Isolation
+
+Use named sessions for parallel testing:
+
+```bash
+agent-browser --session test1 open http://localhost:3000
+agent-browser --session test2 open http://localhost:3001
+agent-browser --session test1 snapshot -c
+agent-browser --session test2 snapshot -c
+agent-browser --session test1 close
+agent-browser --session test2 close
+```
+
+## Common Pitfalls
+
+- **Don't** use CSS selectors when `@ref` from snapshot is available — refs are more reliable
+- **Don't** skip `snapshot` and guess element positions — always observe first
+- **Do** use `snapshot -i` when you only care about interactive elements (faster, less noise)
+- **Do** close the browser when done (`agent-browser close`) to free resources
+
+## Fallback: Python Playwright
+
+For complex batch automation or CI scenarios where agent-browser is insufficient, fall back to Python Playwright scripts:
+
 ```python
 from playwright.sync_api import sync_playwright
 
 with sync_playwright() as p:
-    browser = p.chromium.launch(headless=True) # Always launch chromium in headless mode
+    browser = p.chromium.launch(headless=True)
     page = browser.new_page()
-    page.goto('http://localhost:5173') # Server already running and ready
-    page.wait_for_load_state('networkidle') # CRITICAL: Wait for JS to execute
-    # ... your automation logic
+    page.goto('http://localhost:3000')
+    page.wait_for_load_state('networkidle')
+    # ... automation logic
     browser.close()
 ```
 
-## Reconnaissance-Then-Action Pattern
-
-1. **Inspect rendered DOM**:
-   ```python
-   page.screenshot(path='/tmp/inspect.png', full_page=True)
-   content = page.content()
-   page.locator('button').all()
-   ```
-
-2. **Identify selectors** from inspection results
-
-3. **Execute actions** using discovered selectors
-
-## Common Pitfall
-
-❌ **Don't** inspect the DOM before waiting for `networkidle` on dynamic apps
-✅ **Do** wait for `page.wait_for_load_state('networkidle')` before inspection
-
-## Best Practices
-
-- **Playwright MCP tools available** - If `mcp__playwright__` tools are configured, prefer using them for interactive browser operations (snapshot, click, fill, screenshot). Use Python scripts for batch automation or CI scenarios.
-- **Use bundled scripts as black boxes** - To accomplish a task, consider whether one of the scripts available in `scripts/` can help. These scripts handle common, complex workflows reliably without cluttering the context window. Use `--help` to see usage, then invoke directly.
-- Use `sync_playwright()` for synchronous scripts
-- Always close the browser when done
-- Use descriptive selectors: `text=`, `role=`, CSS selectors, or IDs
-- **Wait strategy**: Prefer `page.wait_for_selector()` for specific elements. Use `networkidle` as a general wait, but fall back to `wait_for_selector()` if the app uses WebSocket/long-polling (where `networkidle` may hang).
-
-## Reference Files
-
-- **examples/** - Examples showing common patterns:
-  - `element_discovery.py` - Discovering buttons, links, and inputs on a page
-  - `static_html_automation.py` - Using file:// URLs for local HTML
-  - `console_logging.py` - Capturing console logs during automation
+**Helper scripts** (for server lifecycle management):
+- `scripts/with_server.py --help` — manages server startup/shutdown around automation scripts


### PR DESCRIPTION
## Summary
- ui-observer agent と webapp-testing skill を Playwright MCP/Python から [agent-browser](https://github.com/vercel-labs/agent-browser) CLI に移行
- アクセシビリティツリーベースのセマンティック参照 (`@e1`, `@e2`) による LLM フレンドリーなブラウザ操作
- CI バッチ用途向けに Python Playwright フォールバックを維持

## Test plan
- [x] `agent-browser open/snapshot/click/screenshot/close` の動作確認済み
- [x] ui-observer.md から Playwright 依存が除去されていることを確認
- [x] webapp-testing SKILL.md に Snapshot-First ワークフローが記述されていることを確認
- [x] Playwright MCP 依存が除去 + フォールバック記述が存在することを確認
- [ ] 実プロジェクトで ui-observer agent を起動してブラウザ操作できることを確認