### PR TITLE
fix(retroactive-scorer): align key names with session-learner output

### DIFF
--- a/.config/claude/scripts/benchmark/retroactive_scorer.py
+++ b/.config/claude/scripts/benchmark/retroactive_scorer.py
@@ -97,7 +97,7 @@ def compute_retroactive_score(usage: dict, session: dict) -> tuple[float, str]:
     reasons = []
 
     # セッションにエラーがあれば減点
-    error_count = session.get("error_count", 0)
+    error_count = session.get("errors_count", 0)
     if error_count == 0:
         score += 1.5
         reasons.append("エラーなし")
@@ -108,13 +108,17 @@ def compute_retroactive_score(usage: dict, session: dict) -> tuple[float, str]:
         score -= 1.0
         reasons.append(f"エラー多発({error_count}件)")
 
-    # セッション完了度
-    if session.get("completed", False):
+    # セッション完了度 (outcome: "clean_success" / "recovery" / "failure")
+    outcome = session.get("outcome", "")
+    if outcome == "clean_success":
         score += 1.0
         reasons.append("セッション正常完了")
+    elif outcome == "recovery":
+        score += 0.5
+        reasons.append("エラーから回復")
 
     # 後続修正の有無（同日に correction があれば減点）
-    corrections = session.get("correction_count", 0)
+    corrections = session.get("corrections", 0)
     if corrections > 0:
         score -= corrections * 0.5
         reasons.append(f"修正{corrections}回")


### PR DESCRIPTION
## Summary

- `retroactive_scorer.py` が読むキー名と `session-learner.py` が書くキー名が不一致で、retroactive scoring が常にデフォルト値にフォールバックしていたバグを修正
- 3つのキー名を修正: `error_count` → `errors_count`、`completed` (bool) → `outcome` (string)、`correction_count` → `corrections`
- `outcome` の値 (`clean_success` / `recovery` / `failure`) に応じた適切なスコアリングロジックに変更

Closes #17

## Test plan

- [x] `uv run pytest tests/` 全56テスト通過
- [x] ruff-check / ruff-format 通過
- [x] conventional-commit フック通過