### PR TITLE
fix(completion-gate): correct misleading commit status message

### DIFF
--- a/.config/claude/scripts/policy/completion-gate.py
+++ b/.config/claude/scripts/policy/completion-gate.py
@@ -312,7 +312,7 @@ def _generate_handback_report() -> str:
         if result.returncode == 0 and result.stdout.strip():
             parts.extend(
                 [
-                    "### 変更済みファイル",
+                    "### 未コミットの変更ファイル",
                     "```",
                     result.stdout.strip(),
                     "```",
@@ -326,7 +326,8 @@ def _generate_handback_report() -> str:
         [
             "### 推奨アクション",
             "1. 失敗テストを確認し、手動で修正を検討してください",
-            "2. 変更済みコードは commit 済みです（作業喪失防止）",
+            "2. working tree に未コミットの変更が残っています。"
+            "必要に応じて commit してください",
             "3. PR を作成する場合は `[WIP]` を title に付加してください",
         ]
     )


### PR DESCRIPTION
## Summary

- `completion-gate.py` の graduated handback レポートで、`git diff --stat HEAD` の結果（未コミットの変更）を「commit 済み」と誤案内していたバグを修正
- L315: 見出しを「変更済みファイル」から「未コミットの変更ファイル」に修正
- L329: 「変更済みコードは commit 済みです」から「working tree に未コミットの変更が残っています。必要に応じて commit してください」に修正

Closes #15

## Test plan

- [x] `uv run pytest tests/` 全56テスト通過
- [x] ruff-check / ruff-format / conventional-commit hook 全通過