### PR TITLE
fix(hooks): FM-010 PASS ログの Write Gate 導入

### DIFF
--- a/.config/claude/scripts/lib/hook_utils.py
+++ b/.config/claude/scripts/lib/hook_utils.py
@@ -123,6 +123,19 @@ def get_emitter() -> Callable:
         return lambda *a, **kw: None
 
 
+def emit_audit_event(audit_type: str, data: dict) -> None:
+    """PASS/clean イベントを audit.jsonl に記録。
+
+    patterns.jsonl には流さない（Issue #22）。
+    """
+    try:
+        from session_events import append_to_learnings
+
+        append_to_learnings("audit", {"audit_type": audit_type, **data})
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(f"emit_audit_event: {exc}\n")
+
+
 # ============================================================================
 # Guard Mode (HOOK_GUARD_MODE: audit / warn / block)
 # ============================================================================

--- a/.config/claude/scripts/policy/prompt-injection-detector.py
+++ b/.config/claude/scripts/policy/prompt-injection-detector.py
@@ -17,7 +17,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
 from hook_utils import (
-    get_emitter,
+    emit_audit_event,
     guard_action,
     load_hook_input,
     rotate_and_append,
@@ -253,9 +253,8 @@ def main() -> None:
             sys.exit(2)
         return
 
-    # Clean — emit tracking event
-    emit = get_emitter()
-    emit("pattern", {"type": "injection_scan", "clean": True})
+    # Clean — audit trail only (not patterns.jsonl; Issue #22)
+    emit_audit_event("injection_scan", {"clean": True})
 
 
 if __name__ == "__main__":

--- a/.config/claude/scripts/policy/skill-security-scan.py
+++ b/.config/claude/scripts/policy/skill-security-scan.py
@@ -249,23 +249,36 @@ def main():
     print(json.dumps(result, indent=2, ensure_ascii=False))
 
     # Emit event for AutoEvolve tracking
-    try:
-        from session_events import emit_event
+    scan_data = {
+        "verdict": verdict,
+        "skill_dir": os.path.basename(skill_dir),
+        "critical": counts["CRITICAL"],
+        "high": counts["HIGH"],
+    }
+    if verdict == "PASS":
+        # Audit trail only — PASS は patterns.jsonl に流さない (Issue #22)
+        try:
+            lib = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                "lib",
+            )
+            if lib not in sys.path:
+                sys.path.insert(0, lib)
+            from hook_utils import emit_audit_event
 
-        emit_event(
-            "pattern",
-            {
-                "type": "skill_security_scan",
-                "verdict": verdict,
-                "skill_dir": os.path.basename(skill_dir),
-                "critical": counts["CRITICAL"],
-                "high": counts["HIGH"],
-            },
-        )
-    except ImportError:
-        sys.stderr.write(
-            "skill-security-scan: session_events not available, skipping emit\n"
-        )
+            emit_audit_event("skill_security_scan", scan_data)
+        except Exception as exc:  # noqa: BLE001
+            sys.stderr.write(f"skill-security-scan: audit emit failed: {exc}\n")
+    else:
+        try:
+            from session_events import emit_event
+
+            emit_event(
+                "pattern",
+                {"type": "skill_security_scan", **scan_data},
+            )
+        except ImportError:
+            sys.stderr.write("skill-security-scan: session_events not available\n")
 
     sys.exit(1 if has_blocking else 0)
 

--- a/tools/cleanup-fm010-pass.py
+++ b/tools/cleanup-fm010-pass.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""One-off cleanup: remove FM-010 PASS entries from patterns.jsonl.
+
+Usage:
+    python3 tools/cleanup-fm010-pass.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+PATTERNS = Path.home() / ".claude" / "agent-memory" / "learnings" / "patterns.jsonl"
+
+
+def main() -> None:
+    dry_run = "--dry-run" in sys.argv
+
+    if not PATTERNS.exists():
+        print("patterns.jsonl not found")
+        return
+
+    lines = PATTERNS.read_text(encoding="utf-8").splitlines()
+    kept: list[str] = []
+    removed = 0
+
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            kept.append(line)
+            continue
+
+        fm = entry.get("failure_mode")
+        entry_type = entry.get("type", "")
+        is_pass_injection = (
+            fm == "FM-010"
+            and entry.get("clean") is True
+            and entry_type == "injection_scan"
+        )
+        is_pass_security = (
+            fm == "FM-010"
+            and entry.get("verdict") == "PASS"
+            and entry_type == "skill_security_scan"
+        )
+        if is_pass_injection or is_pass_security:
+            removed += 1
+        else:
+            kept.append(line)
+
+    print(f"Total: {len(lines)}, Remove: {removed}, Keep: {len(kept)}")
+
+    if dry_run:
+        print("(dry-run, no changes)")
+    else:
+        # Atomic write: tmp → rename to avoid partial writes
+        tmp = PATTERNS.with_suffix(".tmp")
+        tmp.write_text(
+            "\n".join(kept) + ("\n" if kept else ""),
+            encoding="utf-8",
+        )
+        os.replace(tmp, PATTERNS)
+        print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `patterns.jsonl` の S/N 比が 0.6% に劣化していた問題を修正
- `injection_scan` / `skill_security_scan` の PASS 結果を `audit.jsonl` に分離し、`patterns.jsonl` への書き込みをスキップ
- 既存 FM-010 PASS ノイズ 1,262件（53.6%）を除去するクリーンアップスクリプトを追加

## Changes

| ファイル | 変更内容 |
|---|---|
| `hook_utils.py` | `emit_audit_event()` 追加（`learnings/audit.jsonl` に記録） |
| `prompt-injection-detector.py` | clean パスを `emit_audit_event` に切替 |
| `skill-security-scan.py` | verdict ゲート追加（PASS→audit, FAIL→既存 emit_event） |
| `tools/cleanup-fm010-pass.py` | 既存ノイズ除去スクリプト（atomic write, `--dry-run` 対応） |

## Test plan

- [x] `ruff check` — 全ファイル lint パス
- [x] `py_compile` — 全ファイル構文チェックパス
- [x] `cleanup-fm010-pass.py --dry-run` — 1,262件のノイズ検出を確認
- [ ] clean 入力で injection detector 実行 → `audit.jsonl` に記録、`current-session.jsonl` に記録なし
- [ ] FAIL 入力で injection detector → 従来通り `_log_block` + `guard_action` 発火

Closes #22