### PR TITLE
♻️ refactor(skills): revitalize GCP 13 + lefthook + Phase 1b finalize

### DIFF
--- a/.config/claude/skills/alloydb-basics/SKILL.md
+++ b/.config/claude/skills/alloydb-basics/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: alloydb-basics
-description: >-
-  Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and
-  integrates with AlloyDB model context protocol (MCP) tools for automated database operations.
+description: "AlloyDB for PostgreSQL のクラスタ・インスタンス・バックアップ管理と MCP ツール連携を支援する。HA、Read Pool、AI workload 向け PostgreSQL 互換 DB の運用設計。Triggers: 'AlloyDB', 'alloydb', 'alloy db', 'AlloyDB クラスタ', 'AlloyDB バックアップ', 'alloydb mcp', 'AlloyDB HA', 'PostgreSQL 互換', 'GCP postgres', 'AlloyDB AI'. Do NOT use for: Cloud SQL の PostgreSQL (use /cloud-sql-basics)、分析ワークロード (use /bigquery-basics)、非 GCP の PostgreSQL。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # AlloyDB Basics

--- a/.config/claude/skills/bigquery-basics/SKILL.md
+++ b/.config/claude/skills/bigquery-basics/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: bigquery-basics
-description: >-
-  Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery
-  ML and Gemini for advanced data analytics and AI-driven insights. Use when
-  you need to interact with BigQuery, run SQL queries, manage BigQuery
-  resources, or leverage BigQuery's built-in ML capabilities. Also use when
-  performing data analysis, ingesting data into BigQuery, or developing AI
-  applications on BigQuery.
+description: "BigQuery のデータセット・テーブル・クエリ・ジョブ管理を支援する。SQL 実行、データ取り込み、BigQuery ML / Gemini 連携による AI 分析、リソース運用までカバー。Triggers: 'BigQuery', 'BQ クエリ', 'BigQuery ML', 'bq query', 'データウェアハウス', 'BigQuery 分析', 'BQ テーブル', 'BigQuery ingest', 'BigQuery Gemini', 'GCP データ分析'. Do NOT use for: 運用 OLTP DB (use /cloud-sql-basics or /alloydb-basics)、ストリーム取り込み単体の Pub/Sub 設定、IAM 設計 (use /google-cloud-recipe-auth)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # BigQuery Basics

--- a/.config/claude/skills/cloud-run-basics/SKILL.md
+++ b/.config/claude/skills/cloud-run-basics/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cloud-run-basics
-description: >-
-  Manages Cloud Run services, jobs, and worker pools. Use when you need to deploy applications
-  responding to HTTP requests (services), run event-triggered or scheduled tasks (jobs),
-  or handle always-on pull-based background processing (worker pools).
+description: "Cloud Run の services / jobs / worker pools の作成・デプロイ・スケール設定を支援する。HTTP サーバーは services、バッチ・スケジュール実行は jobs、常駐 pull 型は worker pools と用途別に振り分け。Triggers: 'Cloud Run', 'cloud run デプロイ', 'gcloud run deploy', 'サーバーレス', 'コンテナデプロイ', 'Cloud Run job', 'worker pool', 'cloud run scale', 'Cloud Run 設定', 'GCP にデプロイ'. Do NOT use for: GKE (use /gke-basics)、IAM・認証設定 (use /google-cloud-recipe-auth)、信頼性レビュー (use /google-cloud-waf-reliability)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Cloud Run Basics

--- a/.config/claude/skills/cloud-sql-basics/SKILL.md
+++ b/.config/claude/skills/cloud-sql-basics/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: cloud-sql-basics
-description: >-
-  Cloud SQL (MySQL/PostgreSQL/SQL Server) インスタンス作成・説明。バックアップ、HA、
-  セキュア接続を扱う。Use when creating or explaining a Cloud SQL instance or database.
+description: "Cloud SQL (MySQL / PostgreSQL / SQL Server) のインスタンス作成・バックアップ・HA・セキュア接続を支援する。マネージド RDB の運用設計。Triggers: 'Cloud SQL', 'cloud sql', 'cloud sql インスタンス', 'cloud sql backup', 'cloud sql ha', 'MySQL GCP', 'PostgreSQL GCP', 'SQL Server GCP', 'マネージド RDB', 'GCP db 作成'. Do NOT use for: AlloyDB (use /alloydb-basics)、BigQuery (use /bigquery-basics)、Spanner、Firestore (use /firebase-basics)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Cloud SQL Basics

--- a/.config/claude/skills/firebase-basics/SKILL.md
+++ b/.config/claude/skills/firebase-basics/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: firebase-basics
-description: Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.
+description: "Firebase の Firestore / Auth / Hosting / Functions / Storage を扱うモバイル・Web アプリ開発を支援する。SDK 初期化、認証、リアルタイム DB、デプロイの基本パターンを案内。Triggers: 'Firebase', 'firebase', 'firestore', 'firebase auth', 'firebase hosting', 'firebase functions', 'firebase sdk', 'モバイル GCP', 'web app firebase', 'firebase 設定'. Do NOT use for: フル GCP プロジェクト onboarding (use /google-cloud-recipe-onboarding)、純粋な Cloud Functions (use /cloud-run-basics または gcloud)、BigQuery 分析 (use /bigquery-basics)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Firebase Basics

--- a/.config/claude/skills/gemini-api/SKILL.md
+++ b/.config/claude/skills/gemini-api/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gemini-api
-description: Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.
+description: "Agent Platform (旧 Vertex AI) 上で Gemini API を Google Gen AI SDK で扱う。Python / JS-TS / Go / Java / C# の SDK 使用、Live API、ツール呼び出し、マルチメディア生成、キャッシュ、バッチ予測をカバー。Triggers: 'Gemini API', 'gemini api', 'Vertex AI', 'vertex ai', 'Google Gen AI SDK', 'Live API', 'Gemini Python', 'gemini sdk', 'Agent Platform', 'gemini grounding'. Do NOT use for: ローカル Gemini CLI (use /gemini)、Claude API (use /claude-api)、OpenAI / 他社 SDK。"
 origin: external
 compatibility: Requires active Google Cloud credentials and Agent Platform API enabled.
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 IMPORTANT: Agent Platform (full name Gemini Enterprise Agent Platform) was previously named "Vertex AI" and many web resources use the legacy branding.

--- a/.config/claude/skills/gke-basics/SKILL.md
+++ b/.config/claude/skills/gke-basics/SKILL.md
@@ -4,8 +4,10 @@ license: Apache-2.0
 metadata:
   author: Google Cloud
   version: "1.0.0"
-description: "Plan, create, configure production-ready GKE clusters via Autopilot golden path. Networking, Workload Identity, scaling, cost, AI/ML inference. WHEN: create/secure/scale GKE, GKE inference, GKE multi-tenancy, GKE upgrade."
+  pattern: reference
+description: "GKE Autopilot を golden path として、production-ready クラスタの計画・作成・設定を支援する。Networking、Workload Identity、スケーリング、コスト、AI/ML inference、multi-tenancy、upgrade をカバー。Triggers: 'GKE', 'gke', 'Kubernetes GCP', 'k8s GCP', 'Autopilot', 'gke cluster', 'Workload Identity', 'gke デプロイ', 'gke スケール', 'gke inference'. Do NOT use for: Cloud Run (use /cloud-run-basics)、汎用 k8s 学習、IAM 単独設計 (use /google-cloud-recipe-auth)、信頼性レビュー (use /google-cloud-waf-reliability)。"
 origin: external
+user-invocable: true
 ---
 
 # Google Kubernetes Engine (GKE) Basics

--- a/.config/claude/skills/google-cloud-recipe-auth/SKILL.md
+++ b/.config/claude/skills/google-cloud-recipe-auth/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-recipe-auth
-description: Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.
+description: "Google Cloud の認証・認可設計を支援する。human user / service account / Application Default Credentials (ADC) / Workload Identity Federation のベストプラクティスをカバー。Triggers: 'GCP 認証', 'gcloud auth', 'ADC', 'Application Default Credentials', 'GCP IAM', 'service account', 'gcp 権限', 'Workload Identity Federation', 'gcp credentials', 'OAuth GCP'. Do NOT use for: Firebase Auth (use /firebase-basics)、ネットワーク調査 (use /google-cloud-recipe-networking-observability)、セキュリティ全体設計 (use /google-cloud-waf-security)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Authenticating to Google Cloud

--- a/.config/claude/skills/google-cloud-recipe-networking-observability/SKILL.md
+++ b/.config/claude/skills/google-cloud-recipe-networking-observability/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: google-cloud-recipe-networking-observability
-description: >-
-  Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics. Use when investigating VPC Flow Logs, NAT, firewall, or threat logs, querying latency and throughput metrics, or running Connectivity Tests for path diagnostics.
+description: "Google Cloud のネットワーク調査をログ・メトリクス・診断ツールで支援する。VPC Flow Logs、Cloud NAT、firewall、threat log、Connectivity Tests、latency / throughput メトリクスをカバー。Triggers: 'VPC Flow Logs', 'vpc flow', 'Cloud NAT', 'GCP firewall', 'connectivity test', 'gcp ネットワーク調査', 'latency GCP', 'throughput GCP', 'GCP threat log', 'GCP network'. Do NOT use for: アプリ層ログ、信頼性レビュー (use /google-cloud-waf-reliability)、IAM (use /google-cloud-recipe-auth)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Networking Observability Expert

--- a/.config/claude/skills/google-cloud-recipe-onboarding/SKILL.md
+++ b/.config/claude/skills/google-cloud-recipe-onboarding/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-recipe-onboarding
-description: Guidance for a developer's first steps on Google Cloud, covering account creation, billing setup, project management, and deploying a first resource.
+description: "Google Cloud を初めて触る開発者の first step を支援する。アカウント作成、課金設定、プロジェクト管理、最初のリソースデプロイをカバー。Triggers: 'GCP オンボーディング', 'gcp 始める', 'GCP アカウント', 'gcp billing', 'gcp project', 'first GCP', 'GCP セットアップ', 'gcp 入門', 'deploy first GCP', 'GCP 初期設定'. Do NOT use for: 既存プロジェクトの運用、認証単独 (use /google-cloud-recipe-auth)、特定サービスの設定 (use /cloud-run-basics / /gke-basics 等)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Onboarding to Google Cloud

--- a/.config/claude/skills/google-cloud-waf-cost-optimization/SKILL.md
+++ b/.config/claude/skills/google-cloud-waf-cost-optimization/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-waf-cost-optimization
-description: Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.
+description: "Google Cloud Well-Architected Framework (WAF) のコスト最適化ピラーに沿ってワークロードを評価し、build / deploy / manage の各段階で actionable な節約推奨を生成する。Triggers: 'GCP コスト', 'gcp cost', 'WAF cost', 'cost optimization GCP', '料金最適化 GCP', 'GCP 費用', 'billing 最適化', 'gcp 節約', 'FinOps GCP', 'GCP 価格'. Do NOT use for: ネットワーク調査 (use /google-cloud-recipe-networking-observability)、信頼性 (use /google-cloud-waf-reliability)、セキュリティ (use /google-cloud-waf-security)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Well-Architected Framework skill for the Cost Optimization pillar

--- a/.config/claude/skills/google-cloud-waf-reliability/SKILL.md
+++ b/.config/claude/skills/google-cloud-waf-reliability/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-waf-reliability
-description: Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.
+description: "Google Cloud Well-Architected Framework (WAF) の信頼性ピラーに沿ってワークロードを評価し、SLO / HA / DR / capacity 計画の actionable な推奨を生成する。Triggers: 'GCP reliability', 'WAF reliability', 'SLO GCP', 'SLA GCP', 'gcp 信頼性', 'gcp HA', 'gcp 冗長性', 'disaster recovery GCP', 'GCP DR', 'gcp uptime'. Do NOT use for: コスト最適化 (use /google-cloud-waf-cost-optimization)、セキュリティ (use /google-cloud-waf-security)、ネットワーク調査 (use /google-cloud-recipe-networking-observability)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Well-Architected Framework skill for the Reliability pillar

--- a/.config/claude/skills/google-cloud-waf-security/SKILL.md
+++ b/.config/claude/skills/google-cloud-waf-security/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-waf-security
-description: Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.
+description: "Google Cloud Well-Architected Framework (WAF) のセキュリティピラーに沿ってワークロードを評価し、IAM / network security / data protection / operational security の actionable な推奨を生成する。Triggers: 'GCP セキュリティ', 'gcp security', 'WAF security', 'IAM 設計', 'network security GCP', 'gcp 監査', 'data protection GCP', 'セキュリティ設計 GCP', 'GCP IAM レビュー', 'gcp threat'. Do NOT use for: 認証セットアップ単発 (use /google-cloud-recipe-auth)、コスト最適化 (use /google-cloud-waf-cost-optimization)、信頼性 (use /google-cloud-waf-reliability)、ネットワーク調査 (use /google-cloud-recipe-networking-observability)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Well-Architected Framework skill for the Security pillar

--- a/HANDOFF-2026-05-11-skill-revitalization.md
+++ b/HANDOFF-2026-05-11-skill-revitalization.md
@@ -62,14 +62,19 @@ description 改善で auto-invoke discoverability 向上:
    ```
    現状 `core.hooksPath` が `/Users/takeuchishougo/dotfiles/.git/hooks` を指していて lefthook が「Skipping hook sync」状態。pre-commit/commit-msg は動いているが lefthook の自動 sync が無効。
 
-2. **Phase 1b: Plugin-managed 6 件削除判断** (M 規模)
-   - 対象: claude-opus-4-5-migration / codex-result-handling / requesting-code-review / receiving-code-review / obsidian-bases / json-canvas
+2. **Phase 1b: Plugin-managed 5 件削除判断** (M 規模) — **2026-05-13 方針確定: 全件 B (放置)**
+   - 対象 (5 件): codex-result-handling / requesting-code-review / receiving-code-review / obsidian-bases / json-canvas
+   - 6 件目だった `claude-opus-4-5-migration` は **既に未 install** (marketplace に source あるのみ、`installed_plugins.json` 不在、現 session の skill 一覧にも不在) → 対象外
+   - 5 件の親 plugin と巻き添え:
+     - `codex-result-handling` → `codex@openai-codex` (巻き添え: codex-cli-runtime / gpt-5-4-prompting / /rescue / /setup)
+     - `requesting-code-review` / `receiving-code-review` → `superpowers@claude-plugins-official` 5.0.7 (巻き添え: using-superpowers, writing-plans, executing-plans, brainstorming, systematic-debugging, TDD 等常用 8 件)
+     - `obsidian-bases` / `json-canvas` → `obsidian@obsidian-skills` (巻き添え: defuddle, obsidian-cli, obsidian-markdown)
    - skills-lock.json には未登録 → plugin marketplace 経由のため個別 disable 機構なし
-   - 選択肢:
-     - A: plugin 全体 uninstall (副作用: 同じ plugin 内の他 skill も消える)
-     - B: 放置 (plugin auto-update で復活し続ける)
-     - C: plugin marketplace でカスタム fork して該当 skill 除外
-   - 推奨: B（放置）で 60 日後に再判定
+   - 選択肢評価:
+     - A: plugin 全体 uninstall → **棄却** (常用 skill の損失が削除益を大幅に上回る)
+     - B: 放置 → **採用** (description tax ≈ 5×150 = 750 token/session、実害小)
+     - C: marketplace を fork → **棄却** (ROI 最悪、auto-update 喪失 + メンテ負債)
+   - 確定方針: B (放置)、60 日後 (2026-07-09) tally で auto-invoke 0 が続けば upstream に「skill 単位 disable 機構」を issue/PR で提案
 
 3. **Phase 3: Recent skip 50 件改善** (L 規模、subagent 並列推奨)
    - GCP 13 件 (本業使用、description 改善で復活見込み)
@@ -132,3 +137,9 @@ GCP 13 件から始めて、subagent 並列で description 改善を進めて。
 - docs/plans/ subdirectory tracking ✅
 - 観察期間継続中（Day 2 / 60）
 - 次セッション scope = 本ファイル
+
+## 2026-05-13 追記
+
+- lefthook 復活完了: `git config --unset-all --local core.hooksPath` + `lefthook install` で pre-commit/commit-msg 再 sync (lefthook 2.1.6)
+- Phase 1b 確定: 全件 B (放置)、対象は 6 → 5 件に訂正 (上記 §「Phase 1b」参照)
+- 次の優先: Phase 3 (Recent skip 50 件改善、GCP 13 件から)


### PR DESCRIPTION
## Summary

- **Phase 3 batch 1**: GCP 13 件 (alloydb / bigquery / cloud-run / cloud-sql / firebase / gemini-api / gke / google-cloud-recipe-{auth,networking-observability,onboarding} / google-cloud-waf-{cost-optimization,reliability,security}) に skill-description-template を適用。description を 1 行化、日英 trigger 10 個、`Do NOT use for` 境界明示、\`user-invocable: true\` + \`metadata.pattern: reference\` 追加で auto-invoke discoverability 向上。
- **lefthook 復活**: \`core.hooksPath\` (絶対パスを指していた local 設定) を unset + \`lefthook install\` で pre-commit / commit-msg を再 sync (lefthook 2.1.6)。
- **Phase 1b finalize**: HANDOFF-2026-05-11-skill-revitalization.md を訂正。\`claude-opus-4-5-migration\` は既に未 install のため対象外 (6→5 件)。残 5 件は親 plugin (superpowers / codex / obsidian) との同居で uninstall コストが大きく、全件 **B (放置)** で 2026-07-09 tally 再判定の方針を確定。

## 観察期間

GCP 13 件は **2026-07-12** (60 日後) に utilization を再計測し、利用 0 回なら真の dead 判定 → 削除候補に。

## Test plan

- [ ] 次セッション開始時に skill 一覧で新 description が表示されることを確認
- [ ] \`/cloud run デプロイ\` 等の日本語 trigger で該当 skill が auto-invoke 候補に上がるかチェック (smoke)
- [ ] 2026-07-12 で skill_usage_tally.py 再実行、改善後 60 日 utilization 確認

## 関連 plan / handoff

- \`docs/plans/2026-05-09-skill-revitalization-plan.md\` Phase 3
- \`HANDOFF-2026-05-11-skill-revitalization.md\` (Phase 1b 訂正済み)
- \`.config/claude/references/skill-description-template.md\` (適用テンプレ)