### PR TITLE
📝 spec: setup-doctor — 別マシン bootstrap で詰まる 5 症状の動的検出

### DIFF
--- a/.config/claude/skills/alloydb-basics/SKILL.md
+++ b/.config/claude/skills/alloydb-basics/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: alloydb-basics
-description: >-
-  Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and
-  integrates with AlloyDB model context protocol (MCP) tools for automated database operations.
+description: "AlloyDB for PostgreSQL のクラスタ・インスタンス・バックアップ管理と MCP ツール連携を支援する。HA、Read Pool、AI workload 向け PostgreSQL 互換 DB の運用設計。Triggers: 'AlloyDB', 'alloydb', 'alloy db', 'AlloyDB クラスタ', 'AlloyDB バックアップ', 'alloydb mcp', 'AlloyDB HA', 'PostgreSQL 互換', 'GCP postgres', 'AlloyDB AI'. Do NOT use for: Cloud SQL の PostgreSQL (use /cloud-sql-basics)、分析ワークロード (use /bigquery-basics)、非 GCP の PostgreSQL。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # AlloyDB Basics

--- a/.config/claude/skills/bigquery-basics/SKILL.md
+++ b/.config/claude/skills/bigquery-basics/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: bigquery-basics
-description: >-
-  Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery
-  ML and Gemini for advanced data analytics and AI-driven insights. Use when
-  you need to interact with BigQuery, run SQL queries, manage BigQuery
-  resources, or leverage BigQuery's built-in ML capabilities. Also use when
-  performing data analysis, ingesting data into BigQuery, or developing AI
-  applications on BigQuery.
+description: "BigQuery のデータセット・テーブル・クエリ・ジョブ管理を支援する。SQL 実行、データ取り込み、BigQuery ML / Gemini 連携による AI 分析、リソース運用までカバー。Triggers: 'BigQuery', 'BQ クエリ', 'BigQuery ML', 'bq query', 'データウェアハウス', 'BigQuery 分析', 'BQ テーブル', 'BigQuery ingest', 'BigQuery Gemini', 'GCP データ分析'. Do NOT use for: 運用 OLTP DB (use /cloud-sql-basics or /alloydb-basics)、ストリーム取り込み単体の Pub/Sub 設定、IAM 設計 (use /google-cloud-recipe-auth)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # BigQuery Basics

--- a/.config/claude/skills/cloud-run-basics/SKILL.md
+++ b/.config/claude/skills/cloud-run-basics/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cloud-run-basics
-description: >-
-  Manages Cloud Run services, jobs, and worker pools. Use when you need to deploy applications
-  responding to HTTP requests (services), run event-triggered or scheduled tasks (jobs),
-  or handle always-on pull-based background processing (worker pools).
+description: "Cloud Run の services / jobs / worker pools の作成・デプロイ・スケール設定を支援する。HTTP サーバーは services、バッチ・スケジュール実行は jobs、常駐 pull 型は worker pools と用途別に振り分け。Triggers: 'Cloud Run', 'cloud run デプロイ', 'gcloud run deploy', 'サーバーレス', 'コンテナデプロイ', 'Cloud Run job', 'worker pool', 'cloud run scale', 'Cloud Run 設定', 'GCP にデプロイ'. Do NOT use for: GKE (use /gke-basics)、IAM・認証設定 (use /google-cloud-recipe-auth)、信頼性レビュー (use /google-cloud-waf-reliability)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Cloud Run Basics

--- a/.config/claude/skills/cloud-sql-basics/SKILL.md
+++ b/.config/claude/skills/cloud-sql-basics/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: cloud-sql-basics
-description: >-
-  Cloud SQL (MySQL/PostgreSQL/SQL Server) インスタンス作成・説明。バックアップ、HA、
-  セキュア接続を扱う。Use when creating or explaining a Cloud SQL instance or database.
+description: "Cloud SQL (MySQL / PostgreSQL / SQL Server) のインスタンス作成・バックアップ・HA・セキュア接続を支援する。マネージド RDB の運用設計。Triggers: 'Cloud SQL', 'cloud sql', 'cloud sql インスタンス', 'cloud sql backup', 'cloud sql ha', 'MySQL GCP', 'PostgreSQL GCP', 'SQL Server GCP', 'マネージド RDB', 'GCP db 作成'. Do NOT use for: AlloyDB (use /alloydb-basics)、BigQuery (use /bigquery-basics)、Spanner、Firestore (use /firebase-basics)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Cloud SQL Basics

--- a/.config/claude/skills/firebase-basics/SKILL.md
+++ b/.config/claude/skills/firebase-basics/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: firebase-basics
-description: Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.
+description: "Firebase の Firestore / Auth / Hosting / Functions / Storage を扱うモバイル・Web アプリ開発を支援する。SDK 初期化、認証、リアルタイム DB、デプロイの基本パターンを案内。Triggers: 'Firebase', 'firebase', 'firestore', 'firebase auth', 'firebase hosting', 'firebase functions', 'firebase sdk', 'モバイル GCP', 'web app firebase', 'firebase 設定'. Do NOT use for: フル GCP プロジェクト onboarding (use /google-cloud-recipe-onboarding)、純粋な Cloud Functions (use /cloud-run-basics または gcloud)、BigQuery 分析 (use /bigquery-basics)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Firebase Basics

--- a/.config/claude/skills/gemini-api/SKILL.md
+++ b/.config/claude/skills/gemini-api/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gemini-api
-description: Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.
+description: "Agent Platform (旧 Vertex AI) 上で Gemini API を Google Gen AI SDK で扱う。Python / JS-TS / Go / Java / C# の SDK 使用、Live API、ツール呼び出し、マルチメディア生成、キャッシュ、バッチ予測をカバー。Triggers: 'Gemini API', 'gemini api', 'Vertex AI', 'vertex ai', 'Google Gen AI SDK', 'Live API', 'Gemini Python', 'gemini sdk', 'Agent Platform', 'gemini grounding'. Do NOT use for: ローカル Gemini CLI (use /gemini)、Claude API (use /claude-api)、OpenAI / 他社 SDK。"
 origin: external
 compatibility: Requires active Google Cloud credentials and Agent Platform API enabled.
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 IMPORTANT: Agent Platform (full name Gemini Enterprise Agent Platform) was previously named "Vertex AI" and many web resources use the legacy branding.

--- a/.config/claude/skills/gke-basics/SKILL.md
+++ b/.config/claude/skills/gke-basics/SKILL.md
@@ -4,8 +4,10 @@ license: Apache-2.0
 metadata:
   author: Google Cloud
   version: "1.0.0"
-description: "Plan, create, configure production-ready GKE clusters via Autopilot golden path. Networking, Workload Identity, scaling, cost, AI/ML inference. WHEN: create/secure/scale GKE, GKE inference, GKE multi-tenancy, GKE upgrade."
+  pattern: reference
+description: "GKE Autopilot を golden path として、production-ready クラスタの計画・作成・設定を支援する。Networking、Workload Identity、スケーリング、コスト、AI/ML inference、multi-tenancy、upgrade をカバー。Triggers: 'GKE', 'gke', 'Kubernetes GCP', 'k8s GCP', 'Autopilot', 'gke cluster', 'Workload Identity', 'gke デプロイ', 'gke スケール', 'gke inference'. Do NOT use for: Cloud Run (use /cloud-run-basics)、汎用 k8s 学習、IAM 単独設計 (use /google-cloud-recipe-auth)、信頼性レビュー (use /google-cloud-waf-reliability)。"
 origin: external
+user-invocable: true
 ---
 
 # Google Kubernetes Engine (GKE) Basics

--- a/.config/claude/skills/google-cloud-recipe-auth/SKILL.md
+++ b/.config/claude/skills/google-cloud-recipe-auth/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-recipe-auth
-description: Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.
+description: "Google Cloud の認証・認可設計を支援する。human user / service account / Application Default Credentials (ADC) / Workload Identity Federation のベストプラクティスをカバー。Triggers: 'GCP 認証', 'gcloud auth', 'ADC', 'Application Default Credentials', 'GCP IAM', 'service account', 'gcp 権限', 'Workload Identity Federation', 'gcp credentials', 'OAuth GCP'. Do NOT use for: Firebase Auth (use /firebase-basics)、ネットワーク調査 (use /google-cloud-recipe-networking-observability)、セキュリティ全体設計 (use /google-cloud-waf-security)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Authenticating to Google Cloud

--- a/.config/claude/skills/google-cloud-recipe-networking-observability/SKILL.md
+++ b/.config/claude/skills/google-cloud-recipe-networking-observability/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: google-cloud-recipe-networking-observability
-description: >-
-  Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics. Use when investigating VPC Flow Logs, NAT, firewall, or threat logs, querying latency and throughput metrics, or running Connectivity Tests for path diagnostics.
+description: "Google Cloud のネットワーク調査をログ・メトリクス・診断ツールで支援する。VPC Flow Logs、Cloud NAT、firewall、threat log、Connectivity Tests、latency / throughput メトリクスをカバー。Triggers: 'VPC Flow Logs', 'vpc flow', 'Cloud NAT', 'GCP firewall', 'connectivity test', 'gcp ネットワーク調査', 'latency GCP', 'throughput GCP', 'GCP threat log', 'GCP network'. Do NOT use for: アプリ層ログ、信頼性レビュー (use /google-cloud-waf-reliability)、IAM (use /google-cloud-recipe-auth)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Networking Observability Expert

--- a/.config/claude/skills/google-cloud-recipe-onboarding/SKILL.md
+++ b/.config/claude/skills/google-cloud-recipe-onboarding/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-recipe-onboarding
-description: Guidance for a developer's first steps on Google Cloud, covering account creation, billing setup, project management, and deploying a first resource.
+description: "Google Cloud を初めて触る開発者の first step を支援する。アカウント作成、課金設定、プロジェクト管理、最初のリソースデプロイをカバー。Triggers: 'GCP オンボーディング', 'gcp 始める', 'GCP アカウント', 'gcp billing', 'gcp project', 'first GCP', 'GCP セットアップ', 'gcp 入門', 'deploy first GCP', 'GCP 初期設定'. Do NOT use for: 既存プロジェクトの運用、認証単独 (use /google-cloud-recipe-auth)、特定サービスの設定 (use /cloud-run-basics / /gke-basics 等)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Onboarding to Google Cloud

--- a/.config/claude/skills/google-cloud-waf-cost-optimization/SKILL.md
+++ b/.config/claude/skills/google-cloud-waf-cost-optimization/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-waf-cost-optimization
-description: Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.
+description: "Google Cloud Well-Architected Framework (WAF) のコスト最適化ピラーに沿ってワークロードを評価し、build / deploy / manage の各段階で actionable な節約推奨を生成する。Triggers: 'GCP コスト', 'gcp cost', 'WAF cost', 'cost optimization GCP', '料金最適化 GCP', 'GCP 費用', 'billing 最適化', 'gcp 節約', 'FinOps GCP', 'GCP 価格'. Do NOT use for: ネットワーク調査 (use /google-cloud-recipe-networking-observability)、信頼性 (use /google-cloud-waf-reliability)、セキュリティ (use /google-cloud-waf-security)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Well-Architected Framework skill for the Cost Optimization pillar

--- a/.config/claude/skills/google-cloud-waf-reliability/SKILL.md
+++ b/.config/claude/skills/google-cloud-waf-reliability/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-waf-reliability
-description: Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.
+description: "Google Cloud Well-Architected Framework (WAF) の信頼性ピラーに沿ってワークロードを評価し、SLO / HA / DR / capacity 計画の actionable な推奨を生成する。Triggers: 'GCP reliability', 'WAF reliability', 'SLO GCP', 'SLA GCP', 'gcp 信頼性', 'gcp HA', 'gcp 冗長性', 'disaster recovery GCP', 'GCP DR', 'gcp uptime'. Do NOT use for: コスト最適化 (use /google-cloud-waf-cost-optimization)、セキュリティ (use /google-cloud-waf-security)、ネットワーク調査 (use /google-cloud-recipe-networking-observability)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Well-Architected Framework skill for the Reliability pillar

--- a/.config/claude/skills/google-cloud-waf-security/SKILL.md
+++ b/.config/claude/skills/google-cloud-waf-security/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: google-cloud-waf-security
-description: Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.
+description: "Google Cloud Well-Architected Framework (WAF) のセキュリティピラーに沿ってワークロードを評価し、IAM / network security / data protection / operational security の actionable な推奨を生成する。Triggers: 'GCP セキュリティ', 'gcp security', 'WAF security', 'IAM 設計', 'network security GCP', 'gcp 監査', 'data protection GCP', 'セキュリティ設計 GCP', 'GCP IAM レビュー', 'gcp threat'. Do NOT use for: 認証セットアップ単発 (use /google-cloud-recipe-auth)、コスト最適化 (use /google-cloud-waf-cost-optimization)、信頼性 (use /google-cloud-waf-reliability)、ネットワーク調査 (use /google-cloud-recipe-networking-observability)。"
 origin: external
+user-invocable: true
+metadata:
+  pattern: reference
 ---
 
 # Google Cloud Well-Architected Framework skill for the Security pillar

--- a/HANDOFF-2026-05-11-skill-revitalization.md
+++ b/HANDOFF-2026-05-11-skill-revitalization.md
@@ -62,14 +62,19 @@ description 改善で auto-invoke discoverability 向上:
    ```
    現状 `core.hooksPath` が `/Users/takeuchishougo/dotfiles/.git/hooks` を指していて lefthook が「Skipping hook sync」状態。pre-commit/commit-msg は動いているが lefthook の自動 sync が無効。
 
-2. **Phase 1b: Plugin-managed 6 件削除判断** (M 規模)
-   - 対象: claude-opus-4-5-migration / codex-result-handling / requesting-code-review / receiving-code-review / obsidian-bases / json-canvas
+2. **Phase 1b: Plugin-managed 5 件削除判断** (M 規模) — **2026-05-13 方針確定: 全件 B (放置)**
+   - 対象 (5 件): codex-result-handling / requesting-code-review / receiving-code-review / obsidian-bases / json-canvas
+   - 6 件目だった `claude-opus-4-5-migration` は **既に未 install** (marketplace に source あるのみ、`installed_plugins.json` 不在、現 session の skill 一覧にも不在) → 対象外
+   - 5 件の親 plugin と巻き添え:
+     - `codex-result-handling` → `codex@openai-codex` (巻き添え: codex-cli-runtime / gpt-5-4-prompting / /rescue / /setup)
+     - `requesting-code-review` / `receiving-code-review` → `superpowers@claude-plugins-official` 5.0.7 (巻き添え: using-superpowers, writing-plans, executing-plans, brainstorming, systematic-debugging, TDD 等常用 8 件)
+     - `obsidian-bases` / `json-canvas` → `obsidian@obsidian-skills` (巻き添え: defuddle, obsidian-cli, obsidian-markdown)
    - skills-lock.json には未登録 → plugin marketplace 経由のため個別 disable 機構なし
-   - 選択肢:
-     - A: plugin 全体 uninstall (副作用: 同じ plugin 内の他 skill も消える)
-     - B: 放置 (plugin auto-update で復活し続ける)
-     - C: plugin marketplace でカスタム fork して該当 skill 除外
-   - 推奨: B（放置）で 60 日後に再判定
+   - 選択肢評価:
+     - A: plugin 全体 uninstall → **棄却** (常用 skill の損失が削除益を大幅に上回る)
+     - B: 放置 → **採用** (description tax ≈ 5×150 = 750 token/session、実害小)
+     - C: marketplace を fork → **棄却** (ROI 最悪、auto-update 喪失 + メンテ負債)
+   - 確定方針: B (放置)、60 日後 (2026-07-09) tally で auto-invoke 0 が続けば upstream に「skill 単位 disable 機構」を issue/PR で提案
 
 3. **Phase 3: Recent skip 50 件改善** (L 規模、subagent 並列推奨)
    - GCP 13 件 (本業使用、description 改善で復活見込み)
@@ -132,3 +137,9 @@ GCP 13 件から始めて、subagent 並列で description 改善を進めて。
 - docs/plans/ subdirectory tracking ✅
 - 観察期間継続中（Day 2 / 60）
 - 次セッション scope = 本ファイル
+
+## 2026-05-13 追記
+
+- lefthook 復活完了: `git config --unset-all --local core.hooksPath` + `lefthook install` で pre-commit/commit-msg 再 sync (lefthook 2.1.6)
+- Phase 1b 確定: 全件 B (放置)、対象は 6 → 5 件に訂正 (上記 §「Phase 1b」参照)
+- 次の優先: Phase 3 (Recent skip 50 件改善、GCP 13 件から)

--- a/docs/plans/pending/2026-05-13-setup-doctor-plan.md
+++ b/docs/plans/pending/2026-05-13-setup-doctor-plan.md
@@ -13,7 +13,7 @@
 
 ### Phase 1 — Detection MVP (read-only)
 - `scripts/lifecycle/doctor.sh` 新設
-- 5 カテゴリの check 関数を実装 (`check_binary`, `check_symlink`, `check_nix`, `check_hook`, `check_brew`)
+- 5 カテゴリの check 関数を実装 (`check_binary`, `check_nix`, `check_hook`, `check_brew`)。`symlink` カテゴリは新規実装せず `Taskfile.yml` 内で `deps: [validate-symlinks]` として既存 task を引用する (重複排除、pre-mortem 行と一貫)
 - `references/setup-requirements.md` で minimum version を一元定義
 - `Taskfile.yml` に `doctor` + `doctor:<category>` 追加
 - Test fixture: 「困った 5 例」を再現する dry-run スナップショット
@@ -27,13 +27,13 @@
 ### Phase 3 — Optional auto-fix (opt-in)
 - `task doctor:fix` で危険度の低い fix (brew upgrade, symlink relink) を実行
 - 危険な fix (nix profile 切替) はガード付きで confirm
-- 完了条件: Phase 2 の hint のうち idempotent 化できる ≥50% を自動化
+- 完了条件: Phase 2 の hint のうち **safe category (brew upgrade / symlink relink) の idempotent fix 100%**。danger category (nix profile 切替、binary downgrade) は対象外
 
 ## Reversible decisions (撤退条件)
 
 | 決定 | 撤退条件 |
 |---|---|
-| shell script で実装 | `doctor.sh` が 200 行超 OR check 関数が 8 以上 → Rust 再評価 |
+| shell script で実装 | `doctor.sh` が **`.bin/validate_*.sh` の最大行数 × 1.5 倍**を超える OR check 関数が 8 以上 → Rust 再評価。Phase 1 着手時に最大行数を計測し閾値を確定 |
 | Phase 1 を read-only | Phase 1 merge 後 30 日で 0 invocation → harness-stability に従い削除検討 |
 | `references/setup-requirements.md` を YAML | parse コスト > 価値の証跡 (`time task doctor` > 2s) → plain bash array に縮退 |
 
@@ -47,12 +47,16 @@
 | **brew tap drift**: tap だけ追加忘れ | `check_brew` で `homebrew.taps` の宣言と `brew tap` 結果を diff |
 | **Profile mismatch を fail にできない**: 単一 profile マシンでは正常 | `hostname` ベースの heuristic + `~/.dotfiles-profile` override file 検討 (Phase 2) |
 | **既存 `validate-*` との重複**: 同じ check が 2 箇所 | `task doctor` 内で `task: validate-symlinks` を呼ぶ (引用)。新規 `check_symlink` は書かない |
+| **sudo PATH 喪失で `darwin-rebuild` not found**: `sudo` 経由で呼ぶと user PATH が消えて nix 関連 binary が見えない (別マシン bootstrap で頻発) | `check_nix` は `/run/current-system/sw/bin/darwin-rebuild` を絶対パスで存在確認 |
+| **対話型 CLI が stdin 待ちで hang**: codex 等が prompt を出すと doctor 自体が止まる (本セッションで実発生) | 全 external call を `timeout 5s` で wrap、subcommand 確認は `</dev/null` を必ず stdin に与える |
+| **nix-darwin `homebrew.brews` の attrset 形式**: `{ name = "rtk"; args = [ "HEAD" ]; }` を平文 string と一緒に parse 必要 | Phase 1 で `nix eval --json` または awk で両形式に対応、形式不明な entry は WARN |
 
 ## Open questions to resolve before Phase 1
 
 1. **scope creep ガード**: 各 Phase の "done" を客観基準で測れるか? acceptance criteria を Phase 1 着手前に再確認
-2. **codex spec/plan gate**: M 規模なので Phase 1 着手前に codex-plan-reviewer に投げる
+2. **codex spec/plan gate**: M 規模なので Phase 1 着手前に codex-plan-reviewer に投げる (本 PR では `codex review --base master` で実施済み、指摘 P2/P3×2 を反映)
 3. **依存検証先**: minimum version table の権威ソース (rtk は upstream release notes、jq は brew formula、claude は npm package.json)
+4. **既存 `validate-symlinks` カバレッジ調査**: `.bin/validate_symlinks.sh` が現状どの link をチェックしているか棚卸しし、spec の `~/.claude/` / `~/.config/` / `~/.zshrc` カバレッジに抜けがないか Phase 1 着手前に確認 (重複/抜け検出)
 
 ## File touchpoints (estimated, Phase 1)
 

--- a/docs/plans/pending/2026-05-13-setup-doctor-plan.md
+++ b/docs/plans/pending/2026-05-13-setup-doctor-plan.md
@@ -1,0 +1,73 @@
+# Setup Doctor — Implementation Plan
+
+**Spec**: [docs/specs/2026-05-13-setup-doctor.md](../../specs/2026-05-13-setup-doctor.md)
+**Size**: M (Plan → Codex Spec/Plan Gate → Edge Case → Implement → Test → Codex Review Gate → Verify)
+**Branch**: 本 PR は **spec/plan のみ**。実装は別 PR (`feat/setup-doctor-phase1`)。
+
+## Phase breakdown
+
+### Phase 0 — Spec + Plan (this PR)
+- 仕様確定とレビューによる合意形成のみ
+- 実装ファイルゼロ
+- 完了条件: spec/plan が merge され、Phase 1 着手 OK
+
+### Phase 1 — Detection MVP (read-only)
+- `scripts/lifecycle/doctor.sh` 新設
+- 5 カテゴリの check 関数を実装 (`check_binary`, `check_symlink`, `check_nix`, `check_hook`, `check_brew`)
+- `references/setup-requirements.md` で minimum version を一元定義
+- `Taskfile.yml` に `doctor` + `doctor:<category>` 追加
+- Test fixture: 「困った 5 例」を再現する dry-run スナップショット
+- 完了条件: spec の acceptance criteria 6 項目を満たす
+
+### Phase 2 — Repair suggestions (still read-only)
+- 各 finding に対し machine-readable な `hint:` を付与
+- `task doctor --suggest` で fix コマンドの一覧出力 (実行はしない)
+- 完了条件: 全 finding に hint があり、人間が copy-paste で fix 可能
+
+### Phase 3 — Optional auto-fix (opt-in)
+- `task doctor:fix` で危険度の低い fix (brew upgrade, symlink relink) を実行
+- 危険な fix (nix profile 切替) はガード付きで confirm
+- 完了条件: Phase 2 の hint のうち idempotent 化できる ≥50% を自動化
+
+## Reversible decisions (撤退条件)
+
+| 決定 | 撤退条件 |
+|---|---|
+| shell script で実装 | `doctor.sh` が 200 行超 OR check 関数が 8 以上 → Rust 再評価 |
+| Phase 1 を read-only | Phase 1 merge 後 30 日で 0 invocation → harness-stability に従い削除検討 |
+| `references/setup-requirements.md` を YAML | parse コスト > 価値の証跡 (`time task doctor` > 2s) → plain bash array に縮退 |
+
+## Pre-mortem (失敗モード)
+
+| 失敗モード | 対策 |
+|---|---|
+| **過剰検出**: 開発中ブランチで FAIL 連発 → 信頼喪失 | カテゴリごとに `WARN` と `FAIL` を区別、デフォルト exit は FAIL のみ非ゼロ |
+| **PATH 環境差で false-positive**: GUI 起動 vs ターミナル起動 | doctor は **対話シェル前提**と明記、GUI 起動はサポート外 |
+| **rtk のような mid-flight upgrade**: stable と HEAD で挙動差 | minimum version は spec に明記、HEAD 依存は別マーカーで管理 |
+| **brew tap drift**: tap だけ追加忘れ | `check_brew` で `homebrew.taps` の宣言と `brew tap` 結果を diff |
+| **Profile mismatch を fail にできない**: 単一 profile マシンでは正常 | `hostname` ベースの heuristic + `~/.dotfiles-profile` override file 検討 (Phase 2) |
+| **既存 `validate-*` との重複**: 同じ check が 2 箇所 | `task doctor` 内で `task: validate-symlinks` を呼ぶ (引用)。新規 `check_symlink` は書かない |
+
+## Open questions to resolve before Phase 1
+
+1. **scope creep ガード**: 各 Phase の "done" を客観基準で測れるか? acceptance criteria を Phase 1 着手前に再確認
+2. **codex spec/plan gate**: M 規模なので Phase 1 着手前に codex-plan-reviewer に投げる
+3. **依存検証先**: minimum version table の権威ソース (rtk は upstream release notes、jq は brew formula、claude は npm package.json)
+
+## File touchpoints (estimated, Phase 1)
+
+| File | 操作 | 行数概算 |
+|---|---|---|
+| `scripts/lifecycle/doctor.sh` | new | 150-200 |
+| `references/setup-requirements.md` | new | 60-80 |
+| `Taskfile.yml` | edit (task 追記) | +20 |
+| `tests/fixtures/doctor/*.txt` | new | 5 fixtures |
+| `CLAUDE.md` (root) | edit (Taskfile reference 追記) | +2 行以内 |
+
+合計約 250-330 行、L 規模に膨らむ場合は Phase 1 をさらに 1a/1b に分割。
+
+## Out of scope (再掲)
+
+- 自動修復 (Phase 3)
+- GitHub Actions 化
+- 新マシン bootstrap chain orchestration

--- a/docs/specs/2026-05-13-setup-doctor.md
+++ b/docs/specs/2026-05-13-setup-doctor.md
@@ -23,10 +23,10 @@
 
 | カテゴリ | 検出対象 | 失敗時の症状 |
 |---|---|---|
-| `binary` | 必須 binary 存在 + minimum version (rtk≥0.39, jq, gh, task, sheldon, direnv, mise, starship, git, brew, darwin-rebuild, claude) — `darwin-rebuild` は macOS のみ | hook が ENOENT、Taskfile が動かない |
+| `binary` | 必須 binary 存在 + minimum version を **required / recommended / bootstrap-gated** で分類: **required** (不在=FAIL): rtk≥0.39, jq, gh, task, git, brew. **recommended** (不在=WARN): sheldon, direnv, mise, starship, claude (npm経由). **bootstrap-gated** (`darwin-rebuild` は `task nix:bootstrap` 後に出現する前提なので、未実行マシンでは SKIP) | hook が ENOENT、Taskfile が動かない |
 | `symlink` | 既存 `validate-symlinks` を継承し、`~/.claude/`, `~/.config/`, `~/.zshrc` 配下の管理対象 link を確認 | dotfiles の編集が反映されない |
 | `nix` | `nix flake check` + `hostname` と適用済み profile の整合 (private/work) | 別 profile を誤適用、再起動後の設定 drift |
-| `hook` | settings.json の hook `command` を **dry-run smoke test** (空 JSON を stdin で投入し exit code 確認) | Claude Code 上の hook fail |
+| `hook` | settings.json の hook `command` を **静的 validation のみ** (read-only 厳守): (a) 第1トークンを resolve して binary 存在確認、(b) `rtk hook claude` のような subcommand を `<binary> <sub> --help` で「subcommand 認識可否」を確認、(c) `$HOME` 等の env 展開後パス存在確認。**実行 (空 JSON 投入含む) は禁止** — このリポジトリの hook は memory sync / background job / sound 再生等 side effect を持つため、health check のたびにマシン状態を破壊する | Claude Code 上の hook fail |
 | `brew` | nix-darwin `homebrew.brews` + `homebrew.taps` の宣言と `brew list` / `brew tap` の差分 | 宣言したのに未 install / Cellar mismatch / tap 未追加 |
 
 ### Non-goals
@@ -47,14 +47,14 @@
 3. `task doctor:<category>` で個別実行可能 (例: `task doctor:binary`)。
 4. 既存 `task validate` は **変更なし** (互換維持)。`task doctor` は新規 task として並列追加。
 5. `--json` フラグ (将来) のための内部表現は構造化されているが、MVP では plain text 出力で可。
-6. 「困った具体例」5 件 (本 spec 冒頭の表) を**全て検出できる**ことを test fixture で証明。
+6. 「困った具体例」5 件 (本 spec 冒頭の表) を**全て検出できる**ことを **2 系統の fixture** で証明: (a) **input mock** = `PATH` を `tests/fixtures/doctor/bin-stubs/` で前置きし `rtk`/`brew`/`darwin-rebuild` 等を stub script (例: `echo "rtk 0.35.0"; exit 0`) に差し替え、(b) **golden output** = `tests/fixtures/doctor/expected/*.txt` に finding の期待値を保存し diff で比較。実環境の rtk を 0.35 にダウングレードする方式や hook 実行による fixture 生成は禁止。
 
 ## Open questions (decide during plan)
 
-- Q1: 単一 shell script (`scripts/lifecycle/doctor.sh`) か Rust binary (`tools/claude-hooks` 流用) か → **shell first** で開始、200 行超えたら Rust 再検討
-- Q2: minimum version の定義をどこに置くか → `references/setup-requirements.md` に YAML/TOML テーブルで一元化
-- Q3: `task doctor` を pre-commit (lefthook) で走らせるか → **No** (環境依存で flaky になるため手動 only)
-- Q4: hook smoke test の入力 JSON は何を使うか → `tests/fixtures/hook-smoke-input.json` に共通 fixture
+- Q1: minimum version の定義をどこに置くか → `.config/claude/references/setup-requirements.md` に YAML/TOML テーブルで一元化
+- Q2: `task doctor` を pre-commit (lefthook) で走らせるか → **No** (環境依存で flaky になるため手動 only)
+
+(言語選択 (shell vs Rust) と fixture 形式は plan の reversible decisions / 上記 acceptance criteria #6 で確定済み。元 Q4 (hook smoke test 入力) は read-only 化により消滅)
 
 ## Out of scope (explicitly NOT in this PR)
 
@@ -66,6 +66,6 @@
 
 - 既存検証: `Taskfile.yml` の `validate-*` ファミリ
 - ハーネス契約: `docs/agent-harness-contract.md`
-- harness stability: `references/harness-stability.md` (30-day evaluation rule)
-- 撤退条件のひな型: `references/reversible-decisions.md`
-- 失敗モード: `references/pre-mortem-checklist.md`
+- harness stability: `.config/claude/references/harness-stability.md` (30-day evaluation rule)
+- 撤退条件のひな型: `.config/claude/references/reversible-decisions.md`
+- 失敗モード: `.config/claude/references/pre-mortem-checklist.md`

--- a/docs/specs/2026-05-13-setup-doctor.md
+++ b/docs/specs/2026-05-13-setup-doctor.md
@@ -3,6 +3,7 @@
 **Status**: Draft
 **Created**: 2026-05-13
 **Owner**: takeuchi-shogo
+**Platform**: macOS (nix-darwin) only — Linux/WSL は対象外 (`darwin-rebuild` 等 macOS 固有 binary を前提)
 
 ## Why now
 
@@ -22,11 +23,11 @@
 
 | カテゴリ | 検出対象 | 失敗時の症状 |
 |---|---|---|
-| `binary` | 必須 binary 存在 + minimum version (rtk≥0.39, jq, gh, task, sheldon, direnv, mise, starship, git, brew, darwin-rebuild, claude) | hook が ENOENT、Taskfile が動かない |
+| `binary` | 必須 binary 存在 + minimum version (rtk≥0.39, jq, gh, task, sheldon, direnv, mise, starship, git, brew, darwin-rebuild, claude) — `darwin-rebuild` は macOS のみ | hook が ENOENT、Taskfile が動かない |
 | `symlink` | 既存 `validate-symlinks` を継承し、`~/.claude/`, `~/.config/`, `~/.zshrc` 配下の管理対象 link を確認 | dotfiles の編集が反映されない |
 | `nix` | `nix flake check` + `hostname` と適用済み profile の整合 (private/work) | 別 profile を誤適用、再起動後の設定 drift |
 | `hook` | settings.json の hook `command` を **dry-run smoke test** (空 JSON を stdin で投入し exit code 確認) | Claude Code 上の hook fail |
-| `brew` | nix-darwin `homebrew.brews` 宣言と `brew list` の差分 | 宣言したのに未 install / Cellar mismatch |
+| `brew` | nix-darwin `homebrew.brews` + `homebrew.taps` の宣言と `brew list` / `brew tap` の差分 | 宣言したのに未 install / Cellar mismatch / tap 未追加 |
 
 ### Non-goals
 

--- a/docs/specs/2026-05-13-setup-doctor.md
+++ b/docs/specs/2026-05-13-setup-doctor.md
@@ -1,0 +1,70 @@
+# Setup Doctor — Spec
+
+**Status**: Draft
+**Created**: 2026-05-13
+**Owner**: takeuchi-shogo
+
+## Why now
+
+別マシン (work profile) で dotfiles を bootstrap した際、以下の症状が混在して切り分けに時間を要した:
+
+| 症状 | 具体例 (このセッションで遭遇) |
+|---|---|
+| バージョン drift | `rtk` 0.35 のローカルに対し settings.json が 0.39 の `rtk hook claude` を呼んで `[rtk: No such file or directory (os error 2)]` |
+| 未インストールバイナリ | nix-darwin `homebrew.brews` に追加した formula がローカルに未 apply、`task` / `jq` 等の前提 binary 不在 |
+| Symlink 抜け | `~/.claude/` 配下の一部ファイルが dotfiles 管理から漏れて旧版が残存 |
+| Profile mismatch | `darwin-rebuild switch --flake .#private` 想定のマシンで `#work` を適用するなどの取り違え |
+| Hook 起動失敗 | settings.json の hook `command` が PATH 不整合や旧 subcommand で `exit≠0`、Claude Code 上で `Failed with non-blocking status code` 連発 |
+
+既存 `task validate-{configs,agents,readmes,symlinks}` は **静的 syntax 検証のみ**で、上記の動的・環境依存な問題を検出できない。
+
+## Scope (what `task doctor` checks)
+
+| カテゴリ | 検出対象 | 失敗時の症状 |
+|---|---|---|
+| `binary` | 必須 binary 存在 + minimum version (rtk≥0.39, jq, gh, task, sheldon, direnv, mise, starship, git, brew, darwin-rebuild, claude) | hook が ENOENT、Taskfile が動かない |
+| `symlink` | 既存 `validate-symlinks` を継承し、`~/.claude/`, `~/.config/`, `~/.zshrc` 配下の管理対象 link を確認 | dotfiles の編集が反映されない |
+| `nix` | `nix flake check` + `hostname` と適用済み profile の整合 (private/work) | 別 profile を誤適用、再起動後の設定 drift |
+| `hook` | settings.json の hook `command` を **dry-run smoke test** (空 JSON を stdin で投入し exit code 確認) | Claude Code 上の hook fail |
+| `brew` | nix-darwin `homebrew.brews` 宣言と `brew list` の差分 | 宣言したのに未 install / Cellar mismatch |
+
+### Non-goals
+
+- 自動修復は **Phase 2 以降**。本 spec の MVP は **検出のみ** (read-only)。
+- npm/cargo/pip 等の言語別 lockfile 検証は `dependency-auditor` skill 側の責務。
+- ネットワーク依存テスト (homebrew tap reachability、claude.ai 疎通) はスコープ外。
+
+## Acceptance criteria
+
+1. `task doctor` 単体で全カテゴリを順次実行し、終了コードは `failure 0件 → 0`, `≥1件 → 1`。
+2. 各 finding は `[CATEGORY] severity: message (hint)` の 1 行形式で stdout に出力。例:
+   ```
+   [binary] FAIL: rtk 0.35.0 found, requires ≥0.39.0 (run: brew upgrade rtk)
+   [hook]   WARN: command "rtk hook claude" subcommand missing (rtk version too old)
+   [nix]    OK:   hostname=MacBookPro matches profile=private
+   ```
+3. `task doctor:<category>` で個別実行可能 (例: `task doctor:binary`)。
+4. 既存 `task validate` は **変更なし** (互換維持)。`task doctor` は新規 task として並列追加。
+5. `--json` フラグ (将来) のための内部表現は構造化されているが、MVP では plain text 出力で可。
+6. 「困った具体例」5 件 (本 spec 冒頭の表) を**全て検出できる**ことを test fixture で証明。
+
+## Open questions (decide during plan)
+
+- Q1: 単一 shell script (`scripts/lifecycle/doctor.sh`) か Rust binary (`tools/claude-hooks` 流用) か → **shell first** で開始、200 行超えたら Rust 再検討
+- Q2: minimum version の定義をどこに置くか → `references/setup-requirements.md` に YAML/TOML テーブルで一元化
+- Q3: `task doctor` を pre-commit (lefthook) で走らせるか → **No** (環境依存で flaky になるため手動 only)
+- Q4: hook smoke test の入力 JSON は何を使うか → `tests/fixtures/hook-smoke-input.json` に共通 fixture
+
+## Out of scope (explicitly NOT in this PR)
+
+- 自動修復 (`task doctor:fix`) は Phase 2 で別 spec
+- CI 統合は Phase 3 (GitHub Actions matrix で macOS-15 + macOS-14 の health check)
+- 新マシン bootstrap chain (`task install` → `task doctor` → `task nix:bootstrap`) の orchestration
+
+## References
+
+- 既存検証: `Taskfile.yml` の `validate-*` ファミリ
+- ハーネス契約: `docs/agent-harness-contract.md`
+- harness stability: `references/harness-stability.md` (30-day evaluation rule)
+- 撤退条件のひな型: `references/reversible-decisions.md`
+- 失敗モード: `references/pre-mortem-checklist.md`


### PR DESCRIPTION
## Summary
- 別 PC で dotfiles を bootstrap した際に詰まる 5 症状 (rtk バージョン drift / 未 install binary / symlink 抜け / profile mismatch / hook smoke fail) を `task doctor` で動的検出する仕様を確定。
- 既存 `task validate-*` は静的 syntax 検証のみで環境依存問題を検出できないため、新系統として並列追加 (互換維持)。
- 本 PR は **spec + Phase 0 plan のみ**。実装は別 PR (`feat/setup-doctor-phase1`)。

## Motivation (今回遭遇した実例)
今セッションで `Failed with non-blocking status code: [rtk: No such file or directory (os error 2)]` が連発。原因は:
- f47668c で settings.json を `rtk hook claude` (v0.39 新方式) に更新
- ローカル rtk は 0.35.0 のまま → `claude` subcommand が存在せず ENOENT

`task validate-configs` では検出不能 (syntax は正常)。動的な「binary 存在 + minimum version + hook smoke test」の検査系統が必要。

## Scope (5 categories)
| カテゴリ | 検出対象 |
|---|---|
| `binary` | 必須 binary 存在 + minimum version |
| `symlink` | 既存 `validate-symlinks` を継承 |
| `nix` | `nix flake check` + hostname と profile の整合 |
| `hook` | settings.json hook command の dry-run smoke test |
| `brew` | nix-darwin 宣言と `brew list` の差分 |

## Acceptance criteria (抜粋)
- `task doctor` 単体で全カテゴリ実行、`failure≥1 → exit 1`
- `task doctor:<category>` で個別実行可能
- 既存 `task validate` は変更なし (互換維持)
- 「困った 5 例」を test fixture で全て検出証明

## Files
- `docs/specs/2026-05-13-setup-doctor.md` (new, 70 lines)
- `docs/plans/pending/2026-05-13-setup-doctor-plan.md` (new, 73 lines)

## Phase plan
- **Phase 0** (this PR): spec + plan のみ、実装ゼロ
- **Phase 1**: 検出 MVP (read-only) — `scripts/lifecycle/doctor.sh` + `references/setup-requirements.md` + Taskfile
- **Phase 2**: 修復 hint 追加 (`--suggest`)
- **Phase 3**: opt-in 自動 fix (`task doctor:fix`)

## Test plan
- [ ] spec の acceptance criteria が 5 症状を網羅していることをレビューで確認
- [ ] Phase 1 着手前に codex-plan-reviewer で批評 (M 規模のため Codex Spec/Plan Gate 通過)
- [ ] reversible decisions と pre-mortem checklist が plan に明記済み

## Out of scope
- 自動修復 (Phase 3 で別 spec)
- GitHub Actions 化
- 新マシン bootstrap chain orchestration