### PR TITLE
✨ feat(doctor): setup health check Phase 1 (detection MVP)

### DIFF
--- a/.config/claude/references/setup-requirements.md
+++ b/.config/claude/references/setup-requirements.md
@@ -1,0 +1,49 @@
+# Setup Requirements
+
+`scripts/lifecycle/doctor.sh` (= `task doctor`) が参照する minimum version / install 経路の **single source of truth**。
+
+詳細仕様: `docs/specs/2026-05-13-setup-doctor.md`
+
+## 分類
+
+- **required** (不在 = `FAIL`): bootstrap が走らない / Taskfile が動かない
+- **recommended** (不在 = `WARN`): 体験は劣化するが致命的ではない
+- **bootstrap-gated** (`task nix:bootstrap` 後に出現する想定なので未実行マシンでは `SKIP`)
+
+## Table
+
+形式は **bash-parseable な行指向**: doctor.sh が `awk` で `$1 $2 $3` を読む。コメント行 (`#` 始まり) と空行は無視。
+
+各行: `<tier> <name> <min_version_or_-> <probe_command>`
+
+- `tier` = `required` / `recommended` / `bootstrap_gated`
+- `min_version` = semver 文字列、不要なら `-`
+- `probe_command` = stdout からバージョン文字列を取り出す shell command。`{bin}` placeholder は `name` に置換
+
+```setup-requirements
+# tier            name             min       probe_command
+required          rtk              0.39.0    {bin} --version | awk '{print $2}'
+required          jq               1.6       {bin} --version | sed 's/^jq-//'
+required          gh               2.0       {bin} --version | head -1 | awk '{print $3}'
+required          task             3.0       {bin} --version | tr -d 'v'
+required          git              2.30      {bin} --version | awk '{print $3}'
+required          brew             4.0       {bin} --version | head -1 | awk '{print $2}'
+
+recommended       sheldon          -         -
+recommended       direnv           -         -
+recommended       mise             -         -
+recommended       starship         -         -
+recommended       claude           -         {bin} --version | awk '{print $1}'
+
+bootstrap_gated   darwin-rebuild   -         test -x /run/current-system/sw/bin/darwin-rebuild
+```
+
+## 更新方針
+
+- rtk のように commit 由来で minimum version を引き上げたい時はこのファイルを編集する (single source)
+- 新規 binary 追加は **`required` のハードルを慎重に**: 不在で bootstrap 全停止するため、recommended から始めて運用実績を貯める
+- minimum version の権威ソース:
+  - rtk: upstream release notes
+  - jq / gh / git: brew formula のデフォルト
+  - task: go-task release tag
+  - claude: npm `@anthropic-ai/claude-code` の package.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -115,8 +115,11 @@ tasks:
   doctor:
     desc: Run setup health check (binary/symlink/nix/hook/brew) — see docs/specs/2026-05-13-setup-doctor.md
     cmds:
+      # `defer` ensures symlink validation runs even if doctor.sh exits non-zero.
+      # Without it Task stops on the first FAIL and skips symlink checks — but FAIL
+      # is exactly when you want the full report. (Task >= 3.36 syntax.)
+      - defer: { task: validate-symlinks }
       - bash scripts/lifecycle/doctor.sh all
-      - task: validate-symlinks
 
   doctor:binary:
     desc: Check required binaries and minimum versions

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -112,6 +112,37 @@ tasks:
     cmds:
       - ~/dotfiles/.bin/validate_symlinks.sh
 
+  doctor:
+    desc: Run setup health check (binary/symlink/nix/hook/brew) — see docs/specs/2026-05-13-setup-doctor.md
+    cmds:
+      - bash scripts/lifecycle/doctor.sh all
+      - task: validate-symlinks
+
+  doctor:binary:
+    desc: Check required binaries and minimum versions
+    cmds:
+      - bash scripts/lifecycle/doctor.sh binary
+
+  doctor:symlink:
+    desc: Check managed symlinks (delegates to validate-symlinks)
+    cmds:
+      - task: validate-symlinks
+
+  doctor:nix:
+    desc: Check nix-darwin profile/hostname/darwin-rebuild
+    cmds:
+      - bash scripts/lifecycle/doctor.sh nix
+
+  doctor:hook:
+    desc: Statically validate settings.json hook commands (read-only, no execution)
+    cmds:
+      - bash scripts/lifecycle/doctor.sh hook
+
+  doctor:brew:
+    desc: Check declared brews (nix-darwin) vs installed
+    cmds:
+      - bash scripts/lifecycle/doctor.sh brew
+
   upgrade-claude:
     desc: Upgrade Claude Code and apply system prompt patches
     cmds:

--- a/scripts/lifecycle/doctor.sh
+++ b/scripts/lifecycle/doctor.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# scripts/lifecycle/doctor.sh — dotfiles setup health check
+#
+# Usage: doctor.sh [binary|nix|hook|brew|all]
+# Output: [CATEGORY] SEVERITY: message (hint)
+# Exit:   0 if no FAIL, 1 if any FAIL
+#
+# Spec:         docs/specs/2026-05-13-setup-doctor.md
+# Requirements: .config/claude/references/setup-requirements.md
+#
+# Design: read-only. Hook checks do NOT execute hook commands (would mutate state).
+# All external calls wrapped in `timeout 5s` to prevent stdin-hang.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REQ_FILE="${SETUP_DOCTOR_REQ_FILE:-$ROOT_DIR/.config/claude/references/setup-requirements.md}"
+SETTINGS_FILE="${SETUP_DOCTOR_SETTINGS:-$HOME/.claude/settings.json}"
+NIX_FILE="${SETUP_DOCTOR_NIX_FILE:-$ROOT_DIR/nix/darwin/default.nix}"
+HOSTNAME_OVERRIDE="${SETUP_DOCTOR_HOSTNAME:-}"
+
+FAIL_COUNT=0
+WARN_COUNT=0
+OK_COUNT=0
+
+emit() {
+  local cat="$1" sev="$2" msg="$3" hint="${4:-}"
+  if [[ -n "$hint" ]]; then
+    printf "[%-7s] %s: %s (%s)\n" "$cat" "$sev" "$msg" "$hint"
+  else
+    printf "[%-7s] %s: %s\n" "$cat" "$sev" "$msg"
+  fi
+  case "$sev" in
+    FAIL) FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+    WARN) WARN_COUNT=$((WARN_COUNT + 1)) ;;
+    OK|SKIP) OK_COUNT=$((OK_COUNT + 1)) ;;
+  esac
+}
+
+# version_lt A B → exit 0 if A < B (semver), 1 otherwise
+version_lt() {
+  [[ "$1" = "$2" ]] && return 1
+  local lo
+  lo=$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)
+  [[ "$lo" = "$1" ]]
+}
+
+# Read fenced ```setup-requirements block from REQ_FILE, strip comments/blanks.
+read_requirements() {
+  awk '/^```setup-requirements$/{f=1; next} /^```/{f=0} f' "$REQ_FILE" \
+    | grep -vE '^(#|$)'
+}
+
+check_binary() {
+  while IFS=' ' read -r tier name min probe rest; do
+    [[ -z "${tier:-}" ]] && continue
+    # probe may contain spaces; rejoin
+    [[ -n "$rest" ]] && probe="$probe $rest"
+    local bin_path
+    bin_path=$(command -v "$name" 2>/dev/null || true)
+    if [[ -z "$bin_path" ]]; then
+      case "$tier" in
+        required)        emit binary FAIL "$name not found in PATH" "install: brew install $name" ;;
+        recommended)     emit binary WARN "$name not installed (recommended)" "install: brew install $name" ;;
+        bootstrap_gated) emit binary SKIP "$name unavailable (bootstrap-gated, run task nix:bootstrap)" ;;
+      esac
+      continue
+    fi
+    if [[ "$min" = "-" || -z "$probe" || "$probe" = "-" ]]; then
+      emit binary OK "$name found at $bin_path"
+      continue
+    fi
+    local cmd="${probe//\{bin\}/$name}"
+    local ver
+    ver=$(timeout 5 bash -c "$cmd" </dev/null 2>/dev/null || true)
+    if [[ -z "$ver" ]]; then
+      emit binary WARN "$name version probe failed" "cmd: $cmd"
+      continue
+    fi
+    if version_lt "$ver" "$min"; then
+      emit binary FAIL "$name $ver found, requires >= $min" "run: brew upgrade $name"
+    else
+      emit binary OK "$name $ver (>= $min)"
+    fi
+  done < <(read_requirements)
+}
+
+check_nix() {
+  local drb=/run/current-system/sw/bin/darwin-rebuild
+  if [[ ! -x "$drb" ]]; then
+    emit nix SKIP "$drb not found" "run: task nix:bootstrap"
+    return
+  fi
+  emit nix OK "darwin-rebuild present at $drb"
+  local host="${HOSTNAME_OVERRIDE:-$(hostname -s 2>/dev/null || hostname)}"
+  case "$host" in
+    MacBookPro|MacBookPro.local)        emit nix OK   "hostname=$host matches profile=private" ;;
+    MacBookPro-work|MacBookPro-work.*)  emit nix OK   "hostname=$host matches profile=work" ;;
+    *)                                  emit nix WARN "hostname=$host does not match private/work" "verify task nix:switch PROFILE=<...>" ;;
+  esac
+}
+
+check_hook() {
+  if [[ ! -f "$SETTINGS_FILE" ]]; then
+    emit hook FAIL "$SETTINGS_FILE missing" "run: task validate-symlinks"
+    return
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    emit hook SKIP "jq not installed (required to parse settings.json)"
+    return
+  fi
+  # Resolve hook commands without execution. For each command we walk tokens
+  # (whitespace-split) and pick the FIRST one that resolves to an existing path or
+  # PATH entry — skipping env-assignments, quoted-string fragments, and shell
+  # metacharacter prefixes. Bash word-split doesn't handle quoted spaces; that's
+  # why we skip noisy tokens (`*"*`, `*}*`) and keep walking until something
+  # resolves (e.g., `bash`, `python3`, an absolute path).
+  local unresolved=0 total=0
+  while IFS= read -r cmd; do
+    [[ -z "$cmd" ]] && continue
+    total=$((total + 1))
+    local resolved="" t
+    for t in $cmd; do
+      case "$t" in
+        ""|*=*|*\"*|*\'*|*\}*|*\{*|\&\&|\|\|) continue ;;
+      esac
+      t="${t#\(}"; t="${t#\)}"; t="${t#\&}"
+      [[ -z "$t" ]] && continue
+      t="${t/#\~/$HOME}"
+      t="${t//\$HOME/$HOME}"
+      if [[ "$t" == */* ]]; then
+        [[ -x "$t" || -f "$t" ]] && { resolved="$t"; break; }
+      else
+        command -v "$t" >/dev/null 2>&1 && { resolved="$t"; break; }
+      fi
+    done
+    if [[ -z "$resolved" ]]; then
+      emit hook FAIL "no resolvable executable in hook" "cmd: ${cmd:0:60}..."
+      unresolved=$((unresolved + 1))
+    fi
+  done < <(jq -r '..|.command? // empty' "$SETTINGS_FILE" 2>/dev/null | sort -u)
+  [[ $unresolved -eq 0 && $total -gt 0 ]] && emit hook OK "all $total hook commands resolve"
+  # rtk hook claude subcommand recognition (read-only)
+  if command -v rtk >/dev/null 2>&1; then
+    if timeout 5 rtk hook --help </dev/null 2>/dev/null | grep -qE '^[[:space:]]+claude\b'; then
+      emit hook OK "rtk hook claude subcommand recognized"
+    else
+      emit hook FAIL "rtk hook claude subcommand missing" "run: brew upgrade rtk"
+    fi
+  fi
+}
+
+check_brew() {
+  if [[ ! -f "$NIX_FILE" ]]; then
+    emit brew SKIP "$NIX_FILE not found"
+    return
+  fi
+  if ! command -v brew >/dev/null 2>&1; then
+    emit brew SKIP "brew not in PATH"
+    return
+  fi
+  # Extract brews from nix file: handle both `"name"` and `{ name = "name"; ... }`
+  local declared
+  declared=$(awk '
+    /brews[[:space:]]*=/{in_b=1; next}
+    in_b && /\]/{in_b=0}
+    in_b && /name[[:space:]]*=[[:space:]]*"[^"]+"/{
+      s=$0; sub(/.*name[[:space:]]*=[[:space:]]*"/, "", s); sub(/".*/, "", s); print s; next
+    }
+    in_b && /^[[:space:]]*"[^"]+"/{
+      s=$0; sub(/^[[:space:]]*"/, "", s); sub(/".*/, "", s); print s
+    }
+  ' "$NIX_FILE" | sort -u)
+  if [[ -z "$declared" ]]; then
+    emit brew WARN "no brews declared in $NIX_FILE"
+    return
+  fi
+  local installed missing=""
+  installed=$(timeout 10 brew list --formula 2>/dev/null | sort -u || true)
+  while IFS= read -r b; do
+    [[ -z "$b" ]] && continue
+    grep -qx "$b" <<< "$installed" || missing="$missing $b"
+  done <<< "$declared"
+  if [[ -z "${missing// }" ]]; then
+    local count
+    count=$(printf '%s\n' "$declared" | wc -l | tr -d ' ')
+    emit brew OK "all $count declared brews installed"
+  else
+    for b in $missing; do
+      emit brew FAIL "$b declared in nix but not installed" "run: task nix:switch"
+    done
+  fi
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [CATEGORY]
+
+CATEGORY: binary | nix | hook | brew | all (default)
+
+Read-only setup health check. Exits 1 if any FAIL is reported.
+Spec: docs/specs/2026-05-13-setup-doctor.md
+EOF
+}
+
+main() {
+  case "${1:-all}" in
+    binary)    check_binary ;;
+    nix)       check_nix ;;
+    hook)      check_hook ;;
+    brew)      check_brew ;;
+    all)       check_binary; check_nix; check_hook; check_brew ;;
+    -h|--help) usage; exit 0 ;;
+    *)         usage; exit 2 ;;
+  esac
+  echo
+  echo "Summary: FAIL=$FAIL_COUNT WARN=$WARN_COUNT OK=$OK_COUNT"
+  [[ $FAIL_COUNT -gt 0 ]] && exit 1
+  exit 0
+}
+
+main "$@"

--- a/scripts/lifecycle/doctor.sh
+++ b/scripts/lifecycle/doctor.sh
@@ -23,6 +23,18 @@ FAIL_COUNT=0
 WARN_COUNT=0
 OK_COUNT=0
 
+# Portable timeout: GNU coreutils `timeout` is not on stock macOS, and
+# `gtimeout` only exists if `brew install coreutils` was run. Fall back
+# to running the command without a timeout — better than swallowing the
+# probe via `|| true` and silently degrading FAILs to WARNs.
+if command -v timeout >/dev/null 2>&1; then
+  _to() { timeout "$@"; }
+elif command -v gtimeout >/dev/null 2>&1; then
+  _to() { gtimeout "$@"; }
+else
+  _to() { shift; "$@"; }   # drop the duration arg, run directly
+fi
+
 emit() {
   local cat="$1" sev="$2" msg="$3" hint="${4:-}"
   if [[ -n "$hint" ]]; then
@@ -72,7 +84,7 @@ check_binary() {
     fi
     local cmd="${probe//\{bin\}/$name}"
     local ver
-    ver=$(timeout 5 bash -c "$cmd" </dev/null 2>/dev/null || true)
+    ver=$(_to 5 bash -c "$cmd"</dev/null 2>/dev/null || true)
     if [[ -z "$ver" ]]; then
       emit binary WARN "$name version probe failed" "cmd: $cmd"
       continue
@@ -115,6 +127,13 @@ check_hook() {
   # metacharacter prefixes. Bash word-split doesn't handle quoted spaces; that's
   # why we skip noisy tokens (`*"*`, `*}*`) and keep walking until something
   # resolves (e.g., `bash`, `python3`, an absolute path).
+  # Verify settings.json parses before iterating; otherwise silent OK hides
+  # the case where Claude itself cannot load the hook config.
+  local jq_err
+  jq_err=$(jq empty "$SETTINGS_FILE" 2>&1) || {
+    emit hook FAIL "settings.json is not valid JSON" "${jq_err%%$'\n'*}"
+    return
+  }
   local unresolved=0 total=0
   while IFS= read -r cmd; do
     [[ -z "$cmd" ]] && continue
@@ -142,7 +161,7 @@ check_hook() {
   [[ $unresolved -eq 0 && $total -gt 0 ]] && emit hook OK "all $total hook commands resolve"
   # rtk hook claude subcommand recognition (read-only)
   if command -v rtk >/dev/null 2>&1; then
-    if timeout 5 rtk hook --help </dev/null 2>/dev/null | grep -qE '^[[:space:]]+claude\b'; then
+    if _to 5 rtk hook --help </dev/null 2>/dev/null | grep -qE '^[[:space:]]+claude([[:space:]]|$)'; then
       emit hook OK "rtk hook claude subcommand recognized"
     else
       emit hook FAIL "rtk hook claude subcommand missing" "run: brew upgrade rtk"
@@ -159,35 +178,51 @@ check_brew() {
     emit brew SKIP "brew not in PATH"
     return
   fi
-  # Extract brews from nix file: handle both `"name"` and `{ name = "name"; ... }`
-  local declared
-  declared=$(awk '
-    /brews[[:space:]]*=/{in_b=1; next}
-    in_b && /\]/{in_b=0}
-    in_b && /name[[:space:]]*=[[:space:]]*"[^"]+"/{
-      s=$0; sub(/.*name[[:space:]]*=[[:space:]]*"/, "", s); sub(/".*/, "", s); print s; next
-    }
-    in_b && /^[[:space:]]*"[^"]+"/{
-      s=$0; sub(/^[[:space:]]*"/, "", s); sub(/".*/, "", s); print s
-    }
-  ' "$NIX_FILE" | sort -u)
-  if [[ -z "$declared" ]]; then
-    emit brew WARN "no brews declared in $NIX_FILE"
+  # Extract brews and taps from nix file. Both `"name"` (string) and
+  # `{ name = "name"; args = [...]; }` (attrset) forms are supported for brews.
+  # Taps are always plain strings in `homebrew.taps`.
+  _nix_list() {
+    local key="$1"
+    awk -v key="$key" '
+      $0 ~ "(^|[^a-zA-Z_])" key "[[:space:]]*=[[:space:]]*\\["{in_b=1; next}
+      in_b && /\]/{in_b=0}
+      in_b && /name[[:space:]]*=[[:space:]]*"[^"]+"/{
+        s=$0; sub(/.*name[[:space:]]*=[[:space:]]*"/, "", s); sub(/".*/, "", s); print s; next
+      }
+      in_b && /^[[:space:]]*"[^"]+"/{
+        s=$0; sub(/^[[:space:]]*"/, "", s); sub(/".*/, "", s); print s
+      }
+    ' "$NIX_FILE" | sort -u
+  }
+  local brews taps
+  brews=$(_nix_list "brews")
+  taps=$(_nix_list "taps")
+  if [[ -z "$brews" && -z "$taps" ]]; then
+    emit brew WARN "no brews or taps declared in $NIX_FILE"
     return
   fi
-  local installed missing=""
-  installed=$(timeout 10 brew list --formula 2>/dev/null | sort -u || true)
+  local installed installed_taps missing_b="" missing_t=""
+  installed=$(_to 10 brew list --formula 2>/dev/null | sort -u || true)
+  installed_taps=$(_to 10 brew tap 2>/dev/null | sort -u || true)
   while IFS= read -r b; do
     [[ -z "$b" ]] && continue
-    grep -qx "$b" <<< "$installed" || missing="$missing $b"
-  done <<< "$declared"
-  if [[ -z "${missing// }" ]]; then
-    local count
-    count=$(printf '%s\n' "$declared" | wc -l | tr -d ' ')
-    emit brew OK "all $count declared brews installed"
+    grep -qx "$b" <<< "$installed" || missing_b="$missing_b $b"
+  done <<< "$brews"
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    grep -qix "$t" <<< "$installed_taps" || missing_t="$missing_t $t"
+  done <<< "$taps"
+  if [[ -z "${missing_b// }" && -z "${missing_t// }" ]]; then
+    local nb nt
+    nb=$(printf '%s\n' "$brews" | grep -c . || true)
+    nt=$(printf '%s\n' "$taps"  | grep -c . || true)
+    emit brew OK "all declared brews ($nb) and taps ($nt) installed"
   else
-    for b in $missing; do
-      emit brew FAIL "$b declared in nix but not installed" "run: task nix:switch"
+    for b in $missing_b; do
+      emit brew FAIL "$b declared in nix.brews but not installed" "run: task nix:switch"
+    done
+    for t in $missing_t; do
+      emit brew FAIL "$t declared in nix.taps but not tapped" "run: task nix:switch"
     done
   fi
 }

--- a/tests/fixtures/doctor/bin-stubs/rtk
+++ b/tests/fixtures/doctor/bin-stubs/rtk
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+[[ "${1:-}" = "--version" ]] && { echo "rtk 0.35.0"; exit 0; }
+exit 0

--- a/tests/fixtures/doctor/run-tests.sh
+++ b/tests/fixtures/doctor/run-tests.sh
@@ -77,7 +77,7 @@ JSON
 out=$(SETUP_DOCTOR_SETTINGS="$TMP/bad-settings.json" $DOCTOR hook 2>&1 || true)
 assert_contains "04-hook-unresolvable" "$out" '\[hook[[:space:]]*\] FAIL: no resolvable executable in hook'
 
-# ----- Scenario 5: brew drift (declared but not installed) -----
+# ----- Scenario 5: brew formula drift (declared but not installed) -----
 cat > "$TMP/extra-brew.nix" <<'NIX'
 {
   homebrew = {
@@ -88,7 +88,25 @@ cat > "$TMP/extra-brew.nix" <<'NIX'
 }
 NIX
 out=$(SETUP_DOCTOR_NIX_FILE="$TMP/extra-brew.nix" $DOCTOR brew 2>&1 || true)
-assert_contains "05-brew-drift" "$out" '\[brew[[:space:]]*\] FAIL: this-formula-definitely-does-not-exist-xyz declared in nix but not installed'
+assert_contains "05-brew-formula-drift" "$out" '\[brew[[:space:]]*\] FAIL: this-formula-definitely-does-not-exist-xyz declared in nix\.brews but not installed'
+
+# ----- Scenario 6: invalid settings.json -> hook FAIL (not silent OK) -----
+printf '{ this is not json' > "$TMP/broken-settings.json"
+out=$(SETUP_DOCTOR_SETTINGS="$TMP/broken-settings.json" $DOCTOR hook 2>&1 || true)
+assert_contains "06-hook-invalid-json" "$out" '\[hook[[:space:]]*\] FAIL: settings\.json is not valid JSON'
+
+# ----- Scenario 7: brew tap drift (declared but not tapped) -----
+cat > "$TMP/extra-tap.nix" <<'NIX'
+{
+  homebrew = {
+    taps = [
+      "nonexistent-org/nonexistent-tap-xyz"
+    ];
+  };
+}
+NIX
+out=$(SETUP_DOCTOR_NIX_FILE="$TMP/extra-tap.nix" $DOCTOR brew 2>&1 || true)
+assert_contains "07-brew-tap-drift" "$out" '\[brew[[:space:]]*\] FAIL: nonexistent-org/nonexistent-tap-xyz declared in nix\.taps but not tapped'
 
 echo
 echo "=== Summary: PASS=$PASS FAIL=$FAIL ==="

--- a/tests/fixtures/doctor/run-tests.sh
+++ b/tests/fixtures/doctor/run-tests.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# tests/fixtures/doctor/run-tests.sh
+#
+# Verify `task doctor` detects all 5 troubled scenarios from spec.
+# Spec: docs/specs/2026-05-13-setup-doctor.md#acceptance-criteria (#6)
+#
+# Strategy: input-mock (PATH stubs + env override) + assertion (grep on output).
+# We use contains-match (not full golden diff) to keep tests robust against
+# path/hostname variation across machines.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+DOCTOR="bash scripts/lifecycle/doctor.sh"
+FIXT_DIR="tests/fixtures/doctor"
+STUB_DIR="$REPO_ROOT/$FIXT_DIR/bin-stubs"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local name="$1" output="$2" pattern="$3"
+  if printf '%s' "$output" | grep -qE "$pattern"; then
+    printf "  PASS  %s\n" "$name"
+    PASS=$((PASS + 1))
+  else
+    printf "  FAIL  %s\n" "$name"
+    printf "        expected pattern: %s\n" "$pattern"
+    printf "        actual output:\n"
+    printf '%s\n' "$output" | sed 's/^/        | /'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== setup-doctor fixture tests ==="
+
+# Build stub for rtk@0.35 (version drift)
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/rtk" <<'STUB'
+#!/usr/bin/env bash
+[[ "${1:-}" = "--version" ]] && { echo "rtk 0.35.0"; exit 0; }
+exit 0
+STUB
+chmod +x "$STUB_DIR/rtk"
+
+# ----- Scenario 1: rtk version drift (FAIL: 0.35 < 0.39) -----
+out=$(PATH="$STUB_DIR:$PATH" $DOCTOR binary 2>&1 || true)
+assert_contains "01-rtk-drift" "$out" '\[binary[[:space:]]*\] FAIL: rtk 0\.35\.0 found, requires >= 0\.39\.0'
+
+# ----- Scenario 2: missing binary (FAIL: jq not found) -----
+# Empty PATH to force lookup failure (keep /bin for awk/grep used inside doctor.sh)
+out=$(PATH="/usr/bin:/bin" $DOCTOR binary 2>&1 || true)
+assert_contains "02-binary-missing" "$out" '\[binary[[:space:]]*\] (FAIL|WARN): (rtk|jq|gh|task) (not found in PATH|not installed)'
+
+# ----- Scenario 3: profile mismatch (WARN: hostname unknown) -----
+out=$(SETUP_DOCTOR_HOSTNAME="unknown-host-xyz" $DOCTOR nix 2>&1 || true)
+assert_contains "03-profile-mismatch" "$out" '\[nix[[:space:]]*\] WARN: hostname=unknown-host-xyz does not match'
+
+# ----- Scenario 4: hook with unresolvable command -----
+cat > "$TMP/bad-settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "this-binary-does-not-exist-xyz" }
+        ]
+      }
+    ]
+  }
+}
+JSON
+out=$(SETUP_DOCTOR_SETTINGS="$TMP/bad-settings.json" $DOCTOR hook 2>&1 || true)
+assert_contains "04-hook-unresolvable" "$out" '\[hook[[:space:]]*\] FAIL: no resolvable executable in hook'
+
+# ----- Scenario 5: brew drift (declared but not installed) -----
+cat > "$TMP/extra-brew.nix" <<'NIX'
+{
+  homebrew = {
+    brews = [
+      "this-formula-definitely-does-not-exist-xyz"
+    ];
+  };
+}
+NIX
+out=$(SETUP_DOCTOR_NIX_FILE="$TMP/extra-brew.nix" $DOCTOR brew 2>&1 || true)
+assert_contains "05-brew-drift" "$out" '\[brew[[:space:]]*\] FAIL: this-formula-definitely-does-not-exist-xyz declared in nix but not installed'
+
+echo
+echo "=== Summary: PASS=$PASS FAIL=$FAIL ==="
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
PR #39 (spec/plan) の Phase 1 implementation。`task doctor` で別マシン bootstrap の 5 症状 (rtk drift / 未 install / symlink / profile mismatch / hook fail) を **read-only** に動的検出。

## Files
| File | Lines | Note |
|---|---|---|
| `scripts/lifecycle/doctor.sh` | +222 | 5 check 関数 (binary/nix/hook/brew, symlink は引用) |
| `.config/claude/references/setup-requirements.md` | +49 | minimum version の single source |
| `Taskfile.yml` | +31 | `doctor` + `doctor:<category>` 6 task |
| `tests/fixtures/doctor/run-tests.sh` | +95 | 5 症状 fixture |
| `tests/fixtures/doctor/bin-stubs/rtk` | +3 | input-mock stub (rtk 0.35) |

合計 **+400 lines, 5 files**

## Acceptance criteria (spec)
- [x] (1) `task doctor` 全カテゴリ実行、exit 0/1
- [x] (2) `[CATEGORY] severity: message (hint)` 1 行形式
- [x] (3) `task doctor:<cat>` 個別実行 (binary/symlink/nix/hook/brew)
- [x] (4) 既存 `task validate` 無変更 (互換維持)
- [x] (5) plain text 出力 (`--json` は将来)
- [x] (6) 5 症状 fixture 全 PASS (`bash tests/fixtures/doctor/run-tests.sh`)

## 実環境での動作確認
```
$ task doctor
[binary ] OK: rtk 0.39.0 (>= 0.39.0)
[binary ] OK: jq 1.7.1-apple (>= 1.6)
... (略)
[nix    ] OK: hostname=MacBookPro matches profile=private
[hook   ] OK: all 58 hook commands resolve
[hook   ] OK: rtk hook claude subcommand recognized
[brew   ] OK: all 9 declared brews installed
Summary: FAIL=0 WARN=0 OK=17
```

## 議論ポイント (PR レビューで判断)

### 1. doctor.sh 行数閾値超過
plan の reversible-decisions では:
- 閾値: `.bin/validate_*.sh` 最大行 × 1.5 = **170 行**
- 実装: **222 行** (52 行超過)
- ただし check 関数は 4 つ (binary/nix/hook/brew) で「8 以上」未達

選択肢:
- **A. このまま採用** (check 関数数の方が支配的、行数は version probe / hook walker の複雑さ由来)
- B. 50 行圧縮 (helper 抽出、可読性低下リスク)
- C. Rust 移行 (Phase 1a/1b 分割、別 PR)
- D. 閾値再校正 (`validate_symlinks.sh` 113 行は Python 内蔵で異質、pure bash 最大の `validate_configs.sh` 82 行を起点にすべき、その場合 123 行で更に厳しい)

私の推奨: A (採用)、commit message にも記載済み。

### 2. relative path vs `~/dotfiles/`
Taskfile から `bash scripts/lifecycle/doctor.sh` を relative で呼ぶ (worktree 互換)。既存 `~/dotfiles/.bin/validate_*.sh` パターンとは外れる。将来 `validate-*` も relative に refactor する別 PR を提案 (out of scope here)。

## Next steps (Phase 2/3, 別 PR)
- Phase 2: `task doctor --suggest` で hint を machine-readable に
- Phase 3: `task doctor:fix` で safe categories の idempotent fix (brew upgrade / symlink relink)

## Test plan
- [ ] codex review (`codex review --base master`) で本 PR を triangulation
- [ ] 行数閾値の判断確定
- [ ] 別マシン (work profile) でも動作確認