### PR TITLE
feat(nix): manage jj (jujutsu) via home-manager; colocate with git

### DIFF
--- a/.config/jj/config.toml
+++ b/.config/jj/config.toml
@@ -1,0 +1,3 @@
+[user]
+name = "takeuchi-shogo"
+email = "takeuchi-shogo@users.noreply.github.com"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ CLAUDE.local.md
 # Machine-local zsh config
 .config/zsh/local.zsh
 
+# Jujutsu (jj) per-repo runtime state (operation log, repo metadata).
+# Written by jj into ~/.config/jj/repos/<hash>/, which symlinks into dotfiles.
+.config/jj/repos/
+
 # Claude reviewer persona (contains personal data)
 .config/claude/agents/reviewer-*.md
 .config/claude/data/*

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -28,6 +28,7 @@ in
     fzf
     gh
     gnugrep
+    jujutsu
     lua5_4              # pkgs.lua is 5.2.4; sketchybar/colors.lua uses 5.3+ bitwise ops
     neovim
     # Tier 2 tooling (Phase B1 Step 4)
@@ -95,12 +96,13 @@ in
     "llms.txt"      = outLink "llms.txt";
     "ruff.toml"     = outLink "ruff.toml";
 
-    # .config/<tool> dir-level symlinks (12)
+    # .config/<tool> dir-level symlinks (13)
     ".config/aerospace"   = outLink ".config/aerospace";
     ".config/borders"     = outLink ".config/borders";
     ".config/gh"          = outLink ".config/gh";
     ".config/ghostty"     = outLink ".config/ghostty";
     ".config/git"         = outLink ".config/git";
+    ".config/jj"          = outLink ".config/jj";
     ".config/karabiner"   = outLink ".config/karabiner";
     ".config/lazygit"     = outLink ".config/lazygit";
     ".config/nvim"        = outLink ".config/nvim";


### PR DESCRIPTION
## Summary

- `jj` (jujutsu 0.40) を nix-darwin + home-manager で declarative に管理
- 既存 git repo に `jj git init --colocate` で被せ、GitHub への push/PR/CI は従来通り動作
- jj が `~/.config/jj/repos/<hash>/` に書き込む per-repo runtime state を `.gitignore` で除外

## Changes

- `nix/home/default.nix`: `home.packages` に `jujutsu` 追加 + `.config/jj` を home.file で out-of-store symlink (dir count コメント `(12)` → `(13)`)
- `.config/jj/config.toml`: user 設定 (既存 git config と同じ noreply email を流用)
- `.gitignore`: `.config/jj/repos/` を除外 (jj の operation log / metadata)

## Test plan

- [x] `sudo darwin-rebuild switch --flake ./nix#private` で適用
- [x] `jj --version` → `jj 0.40.0`
- [x] `jj git init --colocate` 成功、`master@origin` を track
- [x] `jj file untrack '.config/jj/repos/'` で snapshot から除外確認
- [x] `jj split` → `jj bookmark create` → `jj git push` の初運転 (この PR 自体が成果物)
- [ ] レビュー後、`gh pr merge` で master 取り込み