### PR TITLE
✨ feat(calibration): auto-triage 判断 frontier ロガー + RSI governance 再標的化

### DIFF
--- a/.config/claude/scripts/auto-triage-runner.sh
+++ b/.config/claude/scripts/auto-triage-runner.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Auto-Triage Dry-Run Runner
+#
+# learned 昇格候補を無人分類し .triage/ レポートを生成する (PR は作らない)。
+# Wave3 (mechanical 限定の無人 PR 化) の要否を判断するための 2 週間 calibration 用。
+# dry-run なので artifact 編集・commit・PR・ledger 書き込みは一切しない (auto-triage skill が保証)。
+#
+# Designed for cron (毎朝 9 時):
+#   0 9 * * * ~/.claude/scripts/auto-triage-runner.sh >> ~/.claude/agent-memory/logs/auto-triage-cron.log 2>&1
+
+set -euo pipefail
+
+DOTFILES_DIR="$HOME/dotfiles"
+DATA_DIR="$HOME/.claude/agent-memory"
+LOG_FILE="$DATA_DIR/logs/auto-triage-cron.log"
+TODAY=$(date +%F)
+REPORT="$DOTFILES_DIR/.triage/${TODAY}-triage-report.md"
+
+mkdir -p "$DATA_DIR/logs"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+log "=== Auto-Triage Dry-Run Starting ==="
+
+# 冪等ガード: 今日のレポートが既にあれば二重起動しない
+if [ -f "$REPORT" ]; then
+    log "Today's report already exists ($REPORT). Skipping."
+    exit 0
+fi
+
+# 候補数チェック: 0 件なら claude を起動しない (起動コスト節約 + ノイズ防止)
+CAND=$(python3 "$HOME/.claude/scripts/learner/extract-promotion-candidates.py" 2>/dev/null \
+    | python3 -c "import sys, json; print(json.load(sys.stdin).get('count', 0))" 2>/dev/null \
+    || echo 0)
+if [ "$CAND" -lt 1 ]; then
+    log "No pending learned candidates. Skipping."
+    exit 0
+fi
+log "Pending candidates: $CAND"
+
+# dry-run triage を headless で実行 (auto-triage skill が .triage/ レポートを書く)
+cd "$DOTFILES_DIR"
+claude --print --dangerously-skip-permissions "/auto-triage" >> "$LOG_FILE" 2>&1 || {
+    log "ERROR: Claude CLI failed with exit code $?"
+    exit 1
+}
+
+# fail loud: レポートが生成されたか検証 (silent fail 禁止)
+if [ -f "$REPORT" ]; then
+    log "Report generated: $REPORT"
+else
+    log "WARN: claude ran but no report at $REPORT — auto-triage skill output path may have changed"
+fi
+
+log "=== Auto-Triage Dry-Run Finished ==="

--- a/.config/claude/scripts/learner/calibration-verdict-logger.py
+++ b/.config/claude/scripts/learner/calibration-verdict-logger.py
@@ -102,18 +102,25 @@ def _latest_by_key(entries: list[dict]) -> list[dict]:
 
 
 def compute_stats(entries: list[dict], last: int | None = None) -> dict:
-    """agreement rate (全体 + 分類別) と mechanical-confirmed allowlist を返す。"""
-    verdicts = _latest_by_key(entries)
-    verdicts.sort(key=lambda e: e.get("ts", ""))
-    if last is not None:
-        verdicts = verdicts[-last:]
+    """agreement rate (トレンド) と mechanical-confirmed allowlist を返す。
 
-    total = len(verdicts)
-    agree = sum(1 for e in verdicts if e.get("verdict") == "agree")
+    意味論が異なるため `last` の適用範囲を分ける:
+      - **agreement_rate / per_class / total_verdicts**: トレンド指標 → `last` 窓。
+      - **mechanical_confirmed (Wave3 allowlist)**: 累積成果物 → 常に全期間集計。
+        `last` で truncate すると過去に human-confirmed したキーが allowlist から
+        欠落し Wave3 着手時に不完全になるため (PR #61 review 🟡)。
+    """
+    all_verdicts = _latest_by_key(entries)
+    all_verdicts.sort(key=lambda e: e.get("ts", ""))
+
+    # トレンド統計のみ last 窓を適用
+    windowed = all_verdicts[-last:] if last is not None else all_verdicts
+    total = len(windowed)
+    agree = sum(1 for e in windowed if e.get("verdict") == "agree")
 
     per_class: dict[str, dict] = {}
     for cls in CLASSES:
-        subset = [e for e in verdicts if e.get("auto") == cls]
+        subset = [e for e in windowed if e.get("auto") == cls]
         n = len(subset)
         a = sum(1 for e in subset if e.get("verdict") == "agree")
         per_class[cls] = {
@@ -122,19 +129,21 @@ def compute_stats(entries: list[dict], last: int | None = None) -> dict:
             "agreement_rate": round(a / n, 3) if n else None,
         }
 
-    # Wave3 allowlist: auto==mechanical かつ verdict==agree の scope/key
+    # Wave3 allowlist: 全期間の auto==mechanical かつ verdict==agree (last 非適用)
     confirmed = [
         {"key": e.get("key"), "scope": e.get("scope")}
-        for e in verdicts
+        for e in all_verdicts
         if e.get("auto") == "mechanical" and e.get("verdict") == "agree"
     ]
     confirmed_scopes = sorted({c["scope"] for c in confirmed if c["scope"]})
 
     return {
+        "window": last,  # null=全期間。トレンド統計のみに影響
         "total_verdicts": total,
         "agreement_rate": round(agree / total, 3) if total else None,
         "per_class": per_class,
         "mechanical_confirmed": {
+            "scope_note": "全期間集計 (--last 非適用)",
             "count": len(confirmed),
             "scopes": confirmed_scopes,
             "keys": [c["key"] for c in confirmed],

--- a/.config/claude/scripts/learner/calibration-verdict-logger.py
+++ b/.config/claude/scripts/learner/calibration-verdict-logger.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""auto-triage calibration の人間裁定を記録する判断 frontier ロガー.
+
+auto-triage skill は learned 昇格候補を mechanical/advisory/reject/defer に
+**無人分類** する (dry-run)。calibration phase では人間が日次 .triage レポートを
+見てその分類の正否を裁定する。本ロガーはその裁定を記録し、2 つの価値を生む:
+
+  1. **Wave3 allowlist の素材** — 人間が「mechanical で正しい」と確認した
+     scope/key の集合 = 無人 PR 化を許してよい範囲。
+  2. **判断 frontier メトリクス** — auto-triage の分類が人間の裁定とどれだけ
+     一致するか (agreement rate)。「AI の方針判断が人間に追いついているか」を
+     時系列で観測可能にする個人版指標 (Anthropic 再帰的自己改善記事 Mythos 64%
+     の個人スケール翻訳)。
+
+本ロガーは保存プリミティブであり、裁定の対話駆動は呼び出し側 (calibration
+セッション) が行う。auto-triage skill 本体の dry-run no-write 保証とは独立
+(本ロガーの書き込み先は agent-memory であって repo artifact ではない)。
+
+Usage:
+    # 1 件の裁定を記録
+    calibration-verdict-logger.py log --key <8hex> --scope <s> \
+        --auto mechanical --verdict agree \
+        [--corrected advisory] [--note ...] [--report 2026-06-06]
+
+    # 集計 (agreement rate + mechanical-confirmed allowlist)
+    calibration-verdict-logger.py stats [--last N]
+
+冪等キーは extract-promotion-candidates.py の candidate_key (SHA1) と同一前提。
+stats は key ごとに最新裁定を採用 (last-wins) するため、再裁定で上書きできる。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from storage import get_data_dir, read_jsonl
+
+CLASSES = ("mechanical", "advisory", "reject", "defer")
+VERDICTS = ("agree", "disagree")
+
+
+def _ledger_path() -> Path:
+    return get_data_dir() / "learnings" / "triage-calibration.jsonl"
+
+
+def _validate(v: dict) -> None:
+    """裁定フィールドを検証する。boundary で fail fast (NO-OP フォールバック禁止)。"""
+    auto, verdict, corrected = v.get("auto"), v.get("verdict"), v.get("corrected")
+    if not v.get("key"):
+        raise ValueError("key は必須")
+    if auto not in CLASSES:
+        raise ValueError(f"auto must be one of {CLASSES}, got {auto!r}")
+    if verdict not in VERDICTS:
+        raise ValueError(f"verdict must be one of {VERDICTS}, got {verdict!r}")
+    if corrected is not None and corrected not in CLASSES:
+        raise ValueError(f"corrected must be one of {CLASSES}, got {corrected!r}")
+    if verdict == "agree" and corrected is not None and corrected != auto:
+        raise ValueError("corrected が auto と矛盾 (agree なのに別分類を指定)")
+
+
+def log_verdict(verdict_fields: dict) -> dict:
+    """裁定 1 件を triage-calibration.jsonl に追記する。
+
+    verdict_fields: key(必須) / scope / auto / verdict / corrected / note / report。
+    """
+    _validate(verdict_fields)
+    now = datetime.now()
+    entry = {
+        "date": now.strftime("%Y-%m-%d"),
+        "key": verdict_fields["key"],
+        "scope": verdict_fields.get("scope"),
+        "auto": verdict_fields["auto"],
+        "verdict": verdict_fields["verdict"],
+        "corrected": verdict_fields.get("corrected"),
+        "note": verdict_fields.get("note", ""),
+        "report": verdict_fields.get("report"),
+        "ts": now.isoformat(timespec="seconds"),
+    }
+    path = _ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry
+
+
+def _latest_by_key(entries: list[dict]) -> list[dict]:
+    """key ごとに最新 (ts 昇順で後勝ち) の裁定だけ残す。"""
+    latest: dict[str, dict] = {}
+    for e in entries:
+        k = e.get("key")
+        if not k:
+            continue
+        prev = latest.get(k)
+        if prev is None or e.get("ts", "") >= prev.get("ts", ""):
+            latest[k] = e
+    return list(latest.values())
+
+
+def compute_stats(entries: list[dict], last: int | None = None) -> dict:
+    """agreement rate (全体 + 分類別) と mechanical-confirmed allowlist を返す。"""
+    verdicts = _latest_by_key(entries)
+    verdicts.sort(key=lambda e: e.get("ts", ""))
+    if last is not None:
+        verdicts = verdicts[-last:]
+
+    total = len(verdicts)
+    agree = sum(1 for e in verdicts if e.get("verdict") == "agree")
+
+    per_class: dict[str, dict] = {}
+    for cls in CLASSES:
+        subset = [e for e in verdicts if e.get("auto") == cls]
+        n = len(subset)
+        a = sum(1 for e in subset if e.get("verdict") == "agree")
+        per_class[cls] = {
+            "n": n,
+            "agree": a,
+            "agreement_rate": round(a / n, 3) if n else None,
+        }
+
+    # Wave3 allowlist: auto==mechanical かつ verdict==agree の scope/key
+    confirmed = [
+        {"key": e.get("key"), "scope": e.get("scope")}
+        for e in verdicts
+        if e.get("auto") == "mechanical" and e.get("verdict") == "agree"
+    ]
+    confirmed_scopes = sorted({c["scope"] for c in confirmed if c["scope"]})
+
+    return {
+        "total_verdicts": total,
+        "agreement_rate": round(agree / total, 3) if total else None,
+        "per_class": per_class,
+        "mechanical_confirmed": {
+            "count": len(confirmed),
+            "scopes": confirmed_scopes,
+            "keys": [c["key"] for c in confirmed],
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="auto-triage calibration verdict logger"
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_log = sub.add_parser("log", help="裁定 1 件を記録")
+    p_log.add_argument("--key", required=True, help="候補の冪等キー (SHA1 先頭でも可)")
+    p_log.add_argument("--scope", default=None)
+    p_log.add_argument("--auto", required=True, help=f"auto-triage の分類 {CLASSES}")
+    p_log.add_argument("--verdict", required=True, help=f"人間の裁定 {VERDICTS}")
+    p_log.add_argument(
+        "--corrected", default=None, help="disagree 時の正しい分類 (任意)"
+    )
+    p_log.add_argument("--note", default="")
+    p_log.add_argument(
+        "--report", default=None, help="対象 .triage レポートの日付/パス (任意)"
+    )
+
+    p_stats = sub.add_parser("stats", help="agreement rate + allowlist を集計")
+    p_stats.add_argument("--last", type=int, default=None, help="直近 N 件のみ集計")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "log":
+        entry = log_verdict(
+            {
+                "key": args.key,
+                "scope": args.scope,
+                "auto": args.auto,
+                "verdict": args.verdict,
+                "corrected": args.corrected,
+                "note": args.note,
+                "report": args.report,
+            }
+        )
+        print(json.dumps(entry, ensure_ascii=False))
+        return 0
+
+    if args.cmd == "stats":
+        stats = compute_stats(read_jsonl(_ledger_path()), last=args.last)
+        print(json.dumps(stats, ensure_ascii=False, indent=2))
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.config/claude/scripts/lib/session_events.py
+++ b/.config/claude/scripts/lib/session_events.py
@@ -8,6 +8,8 @@ Usage (from other hooks):
     emit_event("error", {"message": "TypeError", "command": "npm test"})
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/.config/claude/scripts/tests/test_calibration_verdict_logger.py
+++ b/.config/claude/scripts/tests/test_calibration_verdict_logger.py
@@ -1,0 +1,93 @@
+"""Tests for calibration-verdict-logger.py."""
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "learner"))
+
+logger = import_module("calibration-verdict-logger")
+
+
+@pytest.fixture(autouse=True)
+def isolate_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUTOEVOLVE_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _fields(key, auto, verdict, scope="cc", corrected=None):
+    return {
+        "key": key,
+        "scope": scope,
+        "auto": auto,
+        "verdict": verdict,
+        "corrected": corrected,
+        "note": "",
+        "report": "2026-06-06",
+    }
+
+
+class TestLogValidation:
+    def test_missing_key_raises(self):
+        with pytest.raises(ValueError, match="key"):
+            logger.log_verdict(_fields("", "mechanical", "agree"))
+
+    def test_bad_auto_raises(self):
+        with pytest.raises(ValueError, match="auto"):
+            logger.log_verdict(_fields("k1", "bogus", "agree"))
+
+    def test_bad_verdict_raises(self):
+        with pytest.raises(ValueError, match="verdict"):
+            logger.log_verdict(_fields("k1", "mechanical", "maybe"))
+
+    def test_bad_corrected_raises(self):
+        with pytest.raises(ValueError, match="corrected"):
+            logger.log_verdict(
+                _fields("k1", "mechanical", "disagree", corrected="bogus")
+            )
+
+    def test_agree_with_conflicting_corrected_raises(self):
+        with pytest.raises(ValueError, match="矛盾"):
+            logger.log_verdict(
+                _fields("k1", "mechanical", "agree", corrected="advisory")
+            )
+
+    def test_valid_log_writes_entry(self, isolate_data_dir):
+        entry = logger.log_verdict(_fields("k1", "mechanical", "agree"))
+        assert entry["key"] == "k1"
+        ledger = isolate_data_dir / "learnings" / "triage-calibration.jsonl"
+        assert ledger.exists()
+        assert ledger.read_text().strip().count("\n") == 0  # 1 line
+
+
+class TestStats:
+    def test_empty_stats(self):
+        stats = logger.compute_stats([])
+        assert stats["total_verdicts"] == 0
+        assert stats["agreement_rate"] is None
+
+    def test_agreement_rate_and_allowlist(self):
+        logger.log_verdict(_fields("k1", "mechanical", "agree", scope="cc-bash"))
+        logger.log_verdict(_fields("k2", "mechanical", "disagree", scope="review-gate"))
+        logger.log_verdict(_fields("k3", "advisory", "agree", scope="absorb"))
+        stats = logger.compute_stats(logger.read_jsonl(logger._ledger_path()))
+        assert stats["total_verdicts"] == 3
+        assert stats["agreement_rate"] == round(2 / 3, 3)
+        # mechanical: k1 agree, k2 disagree -> allowlist only k1/cc-bash
+        assert stats["mechanical_confirmed"]["count"] == 1
+        assert stats["mechanical_confirmed"]["scopes"] == ["cc-bash"]
+        assert stats["per_class"]["mechanical"]["agreement_rate"] == 0.5
+
+    def test_latest_verdict_wins_on_rejudge(self):
+        # 同一 key を再裁定 -> 最新 (disagree) が採用される
+        logger.log_verdict(_fields("k1", "mechanical", "agree"))
+        logger.log_verdict(
+            _fields("k1", "mechanical", "disagree", corrected="advisory")
+        )
+        stats = logger.compute_stats(logger.read_jsonl(logger._ledger_path()))
+        assert stats["total_verdicts"] == 1
+        assert stats["agreement_rate"] == 0.0
+        assert stats["mechanical_confirmed"]["count"] == 0

--- a/.config/claude/scripts/tests/test_calibration_verdict_logger.py
+++ b/.config/claude/scripts/tests/test_calibration_verdict_logger.py
@@ -91,3 +91,37 @@ class TestStats:
         assert stats["total_verdicts"] == 1
         assert stats["agreement_rate"] == 0.0
         assert stats["mechanical_confirmed"]["count"] == 0
+
+    def test_last_windows_trend_but_not_allowlist(self):
+        # PR #61 review 🟡: --last はトレンド統計のみ窓化、allowlist は全期間維持
+        entries = [
+            {
+                "key": "old",
+                "scope": "cc-bash",
+                "auto": "mechanical",
+                "verdict": "agree",
+                "ts": "2026-06-01T09:00:00",
+            },
+            {
+                "key": "mid",
+                "scope": "review-gate",
+                "auto": "advisory",
+                "verdict": "disagree",
+                "ts": "2026-06-02T09:00:00",
+            },
+            {
+                "key": "new",
+                "scope": "absorb",
+                "auto": "mechanical",
+                "verdict": "agree",
+                "ts": "2026-06-03T09:00:00",
+            },
+        ]
+        stats = logger.compute_stats(entries, last=1)
+        # トレンド: 最新 1 件 (new, agree) のみ
+        assert stats["window"] == 1
+        assert stats["total_verdicts"] == 1
+        assert stats["agreement_rate"] == 1.0
+        # allowlist: 全期間の mechanical+agree (old, new) — mid は advisory で除外
+        assert stats["mechanical_confirmed"]["count"] == 2
+        assert stats["mechanical_confirmed"]["scopes"] == ["absorb", "cc-bash"]

--- a/.config/claude/skills/auto-triage/SKILL.md
+++ b/.config/claude/skills/auto-triage/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: auto-triage
+description: patterns.jsonl の learned 昇格候補を mechanical/advisory/reject/defer に無人分類し dry-run レポートを出す。完全無人 PR 化 (Wave3) の前段 calibration。Triggers: 'auto-triage', 'triage dry-run', '昇格候補を分類', '無人トリアージ'. Do NOT use for: 対話的に昇格して artifact を実際に編集する (use /promote-learnings)、外部記事の取り込み (use /absorb)、コードレビュー (use /review)。
+allowed-tools: Read, Bash, Write, Grep, Glob
+pattern: learned-triage-classification
+---
+
+# Auto-Triage (dry-run)
+
+`patterns.jsonl` の `learned` 昇格候補を**無人で分類**し、レポートだけ出す。
+**この skill は読み取り + レポート生成のみ。artifact を一切編集せず、commit/PR/ledger 書き込みもしない。**
+
+## なぜ dry-run か
+
+完全無人で SKILL.md を日次 Edit するのは echo chamber / 誤学習の蓄積 / PR spam を生む
+(Codex Spec/Plan Gate + 自前 design doc `docs/superpowers/specs/2026-05-31-learned-promotion-loop-design.md`
+が独立して「完全自動は誤爆」と結論)。そこでまず**分類精度を 2 週間 calibrate** する。
+
+このループは段階導入:
+1. **(now) dry-run 分類** — 候補を mechanical/advisory/reject/defer に分け、根拠付きでレポート
+2. **calibration** — 人間がレポートを見て「mechanical 分類が正しいか」を検証、採用分から allowlist を作る
+3. **(Wave3) 無人 PR 化** — allowlist に載った mechanical 種別のみ、決定論ゲート通過後に日次無人 PR
+
+dry-run は state を持たない (ledger に書かない)。分類はスキル改善で変動しうるため、calibration 中は確定させない。
+
+## Workflow
+
+1. **候補を取得**:
+   ```bash
+   python3 ~/.claude/scripts/learner/extract-promotion-candidates.py
+   ```
+   `count` が 0 なら「pending な learned はありません」と報告して終了。
+   コアは promoted-ledger と照合し未処理のみ・importance 降順で返す (冪等)。
+
+2. **上位 N=10 を分類**: importance 上位 10 件について、各候補を下表のいずれかに分類する。
+   分類は `detail` の内容と、既存 artifact の実態 (Grep/Read で確認) に基づく。**推測で膨らませない**。
+
+   | 分類 | 定義 | 判定基準 (客観) | 例 |
+   |------|------|----------------|-----|
+   | **mechanical** | 決定論で検証できる構造改善 | lint / grep / schema / 重複照合で正否が機械的に決まる | 重複ルールの統合、冗長文の削減、leak 除去、typo、行数超過の分割 |
+   | **advisory** | 設計判断系 | 「このルールは妥当か」「優先度」等、主観・文脈依存で機械照合不可 | 新ルールの是非、トレードオフ判断、命名・設計方針 |
+   | **reject** | 昇格不適 | 既存 artifact に同等あり / 一般知識 / ノイズ / scope 不明瞭 | already covered、汎用的すぎる知見 |
+   | **defer** | 情報不足 | 単発で再現性不明、文脈待ち | 1 回限りの観測、根拠が薄い |
+
+   **mechanical と advisory の線引きが肝** (Wave3 の無人化対象は mechanical のみ)。
+   迷ったら advisory に倒す (無人化対象を保守的に狭く保つ)。
+
+3. **echo chamber 観察**: 分類対象の `scope` 分布を集計し、同一 scope / 同じ結論への偏りを記録する。
+   同一 scope が候補の過半を占める、または既存 memory に矛盾・反証する learned があれば明記する
+   (monoculture 化の早期シグナル。design doc リスク3 の watch 条件)。
+
+4. **レポート出力**: `.triage/$(date +%F)-triage-report.md` に書き出す (`.triage/` は .gitignore 済)。
+   ```bash
+   mkdir -p .triage
+   ```
+   レポート構成 (下記テンプレート)。各候補に **key 先頭8桁 / scope / detail 要約 / 推奨 artifact / 分類根拠 / (mechanical なら) 推奨 validation コマンド / 既存重複の有無** を含める。
+
+5. **報告**: 分類内訳 (mechanical N / advisory N / reject N / defer N) と echo chamber 観察を 1 段落で要約。
+   レポートパスを示す。**artifact は変更していないこと**を明示する。
+
+## レポートテンプレート
+
+```markdown
+# Auto-Triage Dry-Run Report — YYYY-MM-DD
+
+候補総数: N (extract-promotion-candidates) / 分類対象: 上位 M
+
+## mechanical (k件) — Wave3 無人 PR 候補
+- `[key8]` scope=<scope>: <detail 要約>
+  - 推奨 artifact: <path>
+  - 根拠: <なぜ機械照合可か>
+  - validation: `<lint/grep コマンド>`
+  - 既存重複: <有無 + 該当箇所>
+
+## advisory (k件) — 人間判断必須
+- `[key8]` scope=<scope>: <detail 要約> / 推奨: <path> / 判断点: <何が主観か>
+
+## reject (k件)
+- `[key8]` scope=<scope>: <理由 (already covered / 一般知識 等)>
+
+## defer (k件)
+- `[key8]` scope=<scope>: <保留理由>
+
+## echo chamber 観察
+- scope 分布: <上位 scope と件数>
+- 偏り: <有無>。反証 learned: <有無>
+- watch 条件該当: <yes/no>
+```
+
+## Constraints
+
+- **dry-run 厳守**: artifact の Edit、git commit、gh pr create、promoted-ledger 書き込みを**一切しない**。出力は `.triage/` レポートのみ
+- **N=10 上限**: 1 回の分類は上位 10 件まで (消化不良防止)
+- **保守的分類**: mechanical と advisory で迷ったら advisory (無人化対象を狭く保つ)
+- **推測で膨らませない**: `detail` に書かれていない改善案を fabricate しない。既存 artifact は Grep/Read で実在確認してから「重複あり」と判定する
+
+## Anti-Patterns
+
+| NG | 理由 |
+|----|------|
+| dry-run なのに artifact を Edit する | このスキルの存在意義 (calibration) が壊れる。編集は /promote-learnings (対話) か Wave3 (無人 PR) の役割 |
+| mechanical を広く取る | Wave3 で無人 PR 化される対象。広く取ると echo chamber/誤学習リスクが戻る。迷ったら advisory |
+| 重複チェックを Grep せず「重複なし」と書く | already covered の見落としは promote-learnings と同じ誤爆。実ファイル確認必須 |
+| 候補を 10 件超分類する | レポートが肥大化し人間の calibration 負荷が上がる。上位 10 件に絞る |
+
+Score: 8/10 — dry-run の境界 (編集しない) を Constraints + Anti-Patterns で二重に固めた。mechanical/advisory の線引き基準が calibration の成否を握るが、これは 2 週間の実データで詰める設計。

--- a/.config/claude/skills/auto-triage/SKILL.md
+++ b/.config/claude/skills/auto-triage/SKILL.md
@@ -18,10 +18,14 @@ pattern: learned-triage-classification
 
 このループは段階導入:
 1. **(now) dry-run 分類** — 候補を mechanical/advisory/reject/defer に分け、根拠付きでレポート
-2. **calibration** — 人間がレポートを見て「mechanical 分類が正しいか」を検証、採用分から allowlist を作る
+2. **calibration** — 人間がレポートを見て「mechanical 分類が正しいか」を検証、採用分から allowlist を作る。
+   裁定は `scripts/learner/calibration-verdict-logger.py log` で記録する (agree/disagree)。
+   `... stats` で agreement rate (判断 frontier 指標) と mechanical-confirmed allowlist を集計。
+   この裁定記録が Wave3 着手の前提データ (詳細: 上記 design doc の Wave3 entry requirements)。
 3. **(Wave3) 無人 PR 化** — allowlist に載った mechanical 種別のみ、決定論ゲート通過後に日次無人 PR
 
 dry-run は state を持たない (ledger に書かない)。分類はスキル改善で変動しうるため、calibration 中は確定させない。
+**calibration の裁定記録は dry-run の no-write 保証の外** (書き込み先は agent-memory であって repo artifact ではない)。
 
 ## Workflow
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ CLAUDE.local.md
 !.config/claude/data/trusted-domains.json
 __pycache__/
 .worktrees/
+.triage/
 
 # Raycast secrets
 .config/raycast/**/secrets*

--- a/docs/plans/active/2026-06-05-rsi-governance-frontier-plan.md
+++ b/docs/plans/active/2026-06-05-rsi-governance-frontier-plan.md
@@ -1,5 +1,24 @@
 # RSI Governance Frontier Plan (A+B+C)
 
+> **⚠️ RETARGETED 2026-06-06** — 実装着手時に、本プランの接続先 (旧 AutoEvolve /improve ループ) が
+> **同日まさに退役・解体中** と判明 (`docs/decommission-log.md`: findings-to-autoevolve no-op化 / autoevolve-runner は死んだ /improve を呼ぶ / autoevolve/* ブランチ不生成)。
+> 死んだパイプラインに B2/B3/C2 を配線するのは NO-OP 残置になるため停止。
+> 同時にユーザーが**後継ループ (learned 昇格 → `auto-triage` dry-run cron) を配線** (commit a3e8c8e/7a1c556/78cc902)。
+> ガバナンスをこの **live ループ**に再標的化し、段階導入に合わせて分割した:
+>
+> | タスク | 状態 | 行き先 |
+> |---|---|---|
+> | **A 判断 frontier 計測** | ✅ **実装済 (2026-06-06)** | `scripts/learner/calibration-verdict-logger.py` + test。auto-triage calibration の人間裁定 (agree/disagree) を記録し agreement rate (個人版 Mythos) と Wave3 allowlist を出す。元の「trigger 無き手動 duel」を calibration (摩擦ゼロの判断 duel) に再標的化 |
+> | **B1 メタ安全保護** | 📋 **Wave3 要件に codify** | design doc `2026-05-31-learned-promotion-loop-design.md` の Wave3 entry requirements |
+> | **B2 drift audit** | 📋 Wave3 要件 (dry-run 期は対象 PR 無し) | 同上 |
+> | **B3 circuit-breaker** | 📋 Wave3 出荷時に実証 (auto-triage-runner 対象) | 同上 |
+> | **C1 捕捉率** | 📋 Wave3 要件 (無人 PR への自動レビュー対象) | 同上 |
+> | **C2 checklist→Analyze** | ❌ **棄却** | 接続先 (findings-to-autoevolve / Analyze→Improve) が /improve 退役で死亡 |
+> | **C3 gaming ガード** | 📋 Wave3 要件 (mechanical/advisory 比率水増し監視) | 同上 |
+>
+> 教訓: ガバナンスは**後付けでなくループ設計に統合**する。dry-run 期は設計上安全なので機構を今ビルドせず Wave3 ゲートに codify した。
+> 以下は再標的化前の原案 (provenance として保持)。
+
 - **Date**: 2026-06-05
 - **Source**: `docs/research/2026-06-05-recursive-self-improvement-anthropic-absorb-analysis.md`
 - **Scale**: L (A=S, B=M, C=M / 計 6+ ファイル)

--- a/docs/superpowers/specs/2026-05-31-learned-promotion-loop-design.md
+++ b/docs/superpowers/specs/2026-05-31-learned-promotion-loop-design.md
@@ -126,3 +126,33 @@ learnings/promoted-ledger.jsonl  (新規・追記専用)
 
 ## 未解決事項
 - **echo chamber の自動ガード**: リスク3 の watch 条件を満たすまで意図的に未実装(YAGNI)。観測トリガーで再検討する。
+
+## Wave3 entry requirements (governance)
+
+出典: RSI governance frontier absorb (`docs/research/2026-06-05-recursive-self-improvement-anthropic-absorb-analysis.md`, Anthropic 再帰的自己改善記事)。
+記事は「自己進化が壊れるとき何が起きるか」(制御喪失 / 検証ボトルネック / 判断 frontier) を扱う。
+本ループの **dry-run 期は設計上安全** (artifact 編集・commit・PR・ledger 書き込みゼロ) なので、
+ガバナンス機構は今ビルドせず、**Wave3 (mechanical 限定の無人 PR 化) の出荷ゲート**として codify する。
+Wave3 を起票するときは下記を同時に満たすこと (後付けでなくループ設計に統合する)。
+
+- **A: 判断 frontier 計測 (実装済み)** — calibration の人間裁定を `calibration-verdict-logger.py` が記録。
+  agreement rate (auto-triage の分類が人間の裁定と一致する率) = 個人版 Mythos 指標。
+  `mechanical_confirmed` の scope/key 集合が **Wave3 allowlist の素材**。
+  Wave3 着手の前提: mechanical 分類の agreement rate が**安定して高い** (calibration 2 週間で確認)。
+- **B1: メタ安全層の自己改変防御 (Wave3 で enforce)** — Wave3 の無人 PR が安全機構ファイルを
+  編集対象にしたら block する PreToolUse hook (`protect-linter-config.py` と同型、保護リストは
+  hook 内ハードコード)。保護対象: `improve-policy.md` / `completion-gate.py` / `gaming-detector.py` /
+  各ゲート hook / この保護 hook 自身。AutoEvolve コンテキスト判定は Wave3 runner が立てる env マーカーで。
+- **B2: 累積 drift audit (Wave3 で enforce)** — Wave3 PR を N 本まとめ、保護対象ファイルの累積 diff で
+  安全機構の段階的弱体化 (ガード削除・閾値緩和) を検出。dry-run 期は対象 PR が無いので不要。
+- **B3: グローバル circuit-breaker (Wave3 出荷時に実証済みにする)** — `~/.claude/agent-memory/AUTOEVOLVE_FROZEN`
+  フラグで `auto-triage-runner.sh` (live cron) + Wave3 runner を一括 no-op 化。kill-switch は
+  「必要になる前に存在」させる。`freeze` skill にトグル記述を追加。
+- **C1: 検証側の捕捉率計測 (Wave3 で enforce)** — Wave3 無人 PR への自動レビューの捕捉率を
+  `review-feedback.jsonl` 基盤の上で集計。生成 (無人 PR) だけ自己改善して検証が固定だと非対称 drift。
+- **C3: review gaming ガード (Wave3 で enforce)** — mechanical/advisory 比率の水増し
+  (無人化対象を増やすため安易に mechanical 分類する gaming) を `gaming-detector.py` の
+  `_detect_*` パターンに追加。dry-run 期は無人化対象が無いので未配線。
+
+→ 元の統合プラン (A+B+C を即実装) は `docs/plans/active/2026-06-05-rsi-governance-frontier-plan.md` を参照。
+本ループ配線後に retarget した経緯もそこに記録。


### PR DESCRIPTION
## 背景

`/rpi` で RSI governance frontier プラン (`docs/plans/active/2026-06-05-...`) を実装しようとしたところ、**着手時にプランの接続先 (旧 AutoEvolve `/improve` ループ) が同日まさに退役・解体中**と判明 (`docs/decommission-log.md`)。死んだパイプラインに配線するのは NO-OP 残置になるため停止し、同時に配線された**後継ループ (`auto-triage` dry-run cron)** にガバナンスを再標的化した。

## 変更内容

| ファイル | 内容 |
|---|---|
| `scripts/learner/calibration-verdict-logger.py` (新規) | **Task A 実装**: auto-triage calibration の人間裁定 (agree/disagree) を記録。`stats` で agreement rate (個人版 Mythos 指標) + Wave3 allowlist を出力 |
| `scripts/tests/test_calibration_verdict_logger.py` (新規) | 9 ケース (fail-fast バリデーション / agreement rate / allowlist / 再裁定 last-wins) |
| `skills/auto-triage/SKILL.md` | calibration step にロガーを配線 + no-write 境界を明記 |
| `docs/superpowers/specs/2026-05-31-learned-promotion-loop-design.md` | **B1/B2/B3/C1/C3 を Wave3 entry requirements として codify** |
| `docs/plans/active/2026-06-05-rsi-governance-frontier-plan.md` | RETARGET banner (経緯・タスク別状態・C2 棄却) |

## 設計判断

- **C2 棄却**: 接続先 (findings-to-autoevolve / Analyze→Improve) が `/improve` 退役で死亡
- **B/C は今ビルドせず codify**: dry-run 期は設計上安全。機構を今足すと解体中の死蔵物を増やすため Wave3 出荷ゲートに移した
- **A の再標的**: 元の「trigger 無き手動 duel」を、人間が既にレポートを見る calibration (摩擦ゼロの判断 duel) に変えた
- 教訓: **ガバナンスは後付けでなくループ設計に統合する**

## 検証

- ✅ ruff: All checks passed
- ✅ pytest: 9 passed
- ✅ CLI スモーク: log/stats/fail-fast 動作確認
- ✅ `task validate-configs`: ok
- ⚠️ `task validate-symlinks`: `.codex`/`.cursor` の missing は本 PR と無関係の既存環境問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)