### PR TITLE
✨ feat(comment-guard): 低価値コメント乱造を予防する PreToolUse hook

### DIFF
--- a/.config/claude/scripts/policy/comment-guard.sh
+++ b/.config/claude/scripts/policy/comment-guard.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+# comment-guard.sh — Edit/Write/MultiEdit で新規コードコメントが純増したら deny する PreToolUse hook。
+#
+# 目的: 低価値コメント (作業経過・自明・意図) の乱造を予防する。コメントはデフォルト禁止とし、
+#       書くなら「そうしないと何が起きるか (ハザード・制約)」の Tier 1 だけを意識的 override で書く。
+#       経緯・意図は git commit message に置く。設計: docs/plans/2026-06-06-comment-guard-hook-design.md
+#
+# 設計上の必然 (鈍いまま): hook は Tier を判定しない。pragma 以外のコメント純増を一律 deny する。
+#                          Tier 判定を hook に持ち込むと determinism boundary を壊すため。
+# fail-open: 判定不能・対象外・スクリプト自体のエラーはすべて exit 0 (=allow)。
+# 無効化: COMMENT_GUARD=off (セッションキルスイッチ) または marker touch (30 分有効) で override。
+#
+# Adapted from MH4GF/claude-code user-scope/hooks/comment-guard.sh (MIT License, Copyright (c) 2026 MH4GF).
+# 変更点: rust (.rs) を c-family に追加 / deny メッセージを Tier 哲学に差し替え / marker 運用を dotfiles 向けに記述。
+
+input=$(cat)
+
+[[ "${COMMENT_GUARD:-}" == "off" ]] && exit 0
+
+tool_name=$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null) || exit 0
+case "$tool_name" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+file_path=$(jq -r '.tool_input.file_path // empty' <<<"$input" 2>/dev/null) || exit 0
+[ -n "$file_path" ] || exit 0
+
+ext=$(printf '%s' "$file_path" | tr '[:upper:]' '[:lower:]')
+ext="${ext##*.}"
+case "$ext" in
+  ts|tsx|js|jsx|mjs|cjs|go|rs) family=c ;;
+  json)                        family=json ;;
+  yaml|yml|py)                 family=hash ;;
+  sql)                         family=sql ;;
+  *) exit 0 ;;
+esac
+
+case "$family" in
+  hash) awk_fam=hash ;;
+  sql)  awk_fam=sql ;;
+  *)    awk_fam=c ;;
+esac
+
+count_comments() {
+  printf '%s\n' "$1" | awk -v fam="$awk_fam" '
+  {
+    line = $0
+    sub(/^[ \t]+/, "", line)
+    if (fam == "hash") {
+      if (line ~ /^#!/) next
+      if (line ~ /#[ \t]*(noqa|type:|pylint:|pragma:|yamllint|nosec|fmt:|mypy:)/) next
+      gsub(/"[^"]*"/, "", line)
+      gsub(/\047[^\047]*\047/, "", line)
+      if (line ~ /(^|[ \t])#/) c++
+    } else if (fam == "sql") {
+      if (line ~ /^#!/) next
+      gsub(/"[^"]*"/, "", line)
+      gsub(/\047[^\047]*\047/, "", line)
+      gsub(/`[^`]*`/, "", line)
+      if (line ~ /--/ || line ~ /\/\*/) c++
+    } else {
+      if (line ~ /^#!/) next
+      if (line ~ /\/\/go:/) next
+      if (line ~ /(\/\/|\/\*)[ \t]*(eslint-|@ts-|@flow|biome-ignore|prettier-ignore|oxlint-|deno-lint-|c8 ignore|v8 ignore|istanbul ignore|nolint)/) next
+      gsub(/"[^"]*"/, "", line)
+      gsub(/\047[^\047]*\047/, "", line)
+      gsub(/`[^`]*`/, "", line)
+      if (line ~ /\/\// || line ~ /\/\*/) c++
+    }
+  }
+  END { print c+0 }
+  ' 2>/dev/null
+}
+
+# 1 edit の (old,new) からコメント行数の増分を算出。
+# マルチライン文字列ガードに該当したら判定をスキップし 0 を返す。
+contribution() {
+  local old=$1 new=$2 bt cold cnew
+  if [ "$family" = c ]; then
+    bt=$(printf '%s' "$new" | tr -cd '`' | wc -c | tr -d ' ')
+    [ -n "$bt" ] && [ $((bt % 2)) -ne 0 ] && { echo 0; return; }
+  elif [ "$family" = hash ]; then
+    printf '%s\n' "$new" | grep -qE ':[[:space:]]*[|>][+-]?[0-9]?[[:space:]]*$' && { echo 0; return; }
+  fi
+  cold=$(count_comments "$old"); cold=${cold:-0}
+  cnew=$(count_comments "$new"); cnew=${cnew:-0}
+  echo $((cnew - cold))
+}
+
+total=0
+case "$tool_name" in
+  Edit)
+    old=$(jq -r '.tool_input.old_string // ""' <<<"$input" 2>/dev/null)
+    new=$(jq -r '.tool_input.new_string // ""' <<<"$input" 2>/dev/null)
+    c=$(contribution "$old" "$new"); total=$((total + ${c:-0}))
+    ;;
+  Write)
+    [ -f "$file_path" ] || exit 0
+    old=$(cat "$file_path" 2>/dev/null) || exit 0
+    new=$(jq -r '.tool_input.content // ""' <<<"$input" 2>/dev/null)
+    c=$(contribution "$old" "$new"); total=$((total + ${c:-0}))
+    ;;
+  MultiEdit)
+    n=$(jq '.tool_input.edits | length' <<<"$input" 2>/dev/null)
+    [ -n "$n" ] || exit 0
+    i=0
+    while [ "$i" -lt "$n" ] 2>/dev/null; do
+      old=$(jq -r ".tool_input.edits[$i].old_string // \"\"" <<<"$input" 2>/dev/null)
+      new=$(jq -r ".tool_input.edits[$i].new_string // \"\"" <<<"$input" 2>/dev/null)
+      c=$(contribution "$old" "$new"); total=$((total + ${c:-0}))
+      i=$((i + 1))
+    done
+    ;;
+esac
+
+[ "${total:-0}" -gt 0 ] 2>/dev/null || exit 0
+
+# deny 候補。marker (.claude/tmp/.comment-guard-allow) が 30 分以内に touch されていれば許可する。
+# marker は私が Bash で明示 touch する or ユーザーが手動 touch する (tool call として可視・監査可能)。
+cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)
+if [ -n "$cwd" ]; then
+  marker="$cwd/.claude/tmp/.comment-guard-allow"
+  if [ -f "$marker" ] && [ -n "$(find "$marker" -mmin -30 2>/dev/null)" ]; then
+    exit 0
+  fi
+fi
+
+printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"新規コードコメントの追加はブロックされています。経緯・意図は git commit message に書いてください。コードに残すなら「そうしないと何が起きるか (ハザード・制約)」を書く Tier 1 コメントに限り、その場合はユーザーに確認のうえ override (COMMENT_GUARD=off または .claude/tmp/.comment-guard-allow を touch) してください。"}}'
+exit 0

--- a/.config/claude/scripts/policy/test-comment-guard.sh
+++ b/.config/claude/scripts/policy/test-comment-guard.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+# comment-guard hook のオフライン単体テスト。
+# stdin に JSON を流し、deny JSON が出れば "deny"、無出力なら "allow" と判定する。
+# Adapted from MH4GF/claude-code tests/test-comment-guard.sh (MIT License, Copyright (c) 2026 MH4GF).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/comment-guard.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: $HOOK not found"
+  exit 1
+fi
+
+pass=0
+fail=0
+
+# run_case <name> <payload-json> <allow|deny> [env-assignment]
+run_case() {
+  local name=$1 payload=$2 expected=$3 envp=${4:-}
+  local out got
+  if [ -n "$envp" ]; then
+    out=$(printf '%s' "$payload" | env "$envp" bash "$HOOK" 2>/dev/null)
+  else
+    out=$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null)
+  fi
+  got=allow
+  printf '%s' "$out" | grep -q '"permissionDecision":"deny"' && got=deny
+  if [ "$got" = "$expected" ]; then
+    echo "PASS $name"
+    pass=$((pass+1))
+  else
+    echo "FAIL $name: got=$got want=$expected"
+    fail=$((fail+1))
+  fi
+}
+
+# 1. .ts 行頭コメント追加 → deny
+run_case "ts line-head comment" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"const a=1;",new_string:"// added\nconst a=1;"}}')" \
+  deny
+
+# 2. .ts 行末コメント追加 → deny
+run_case "ts trailing comment" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"foo();",new_string:"foo(); // explain"}}')" \
+  deny
+
+# 3. 文字列リテラル内の // (URL) → allow
+run_case "url in string literal" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"const a=1;",new_string:"const u = \"https://example.com\";"}}')" \
+  allow
+
+# 4. コメント文言の書き換え (行数同じ) → allow
+run_case "comment reword same count" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"// old text\nconst a=1;",new_string:"// new text\nconst a=1;"}}')" \
+  allow
+
+# 5. コメント削除 (行数減) → allow
+run_case "comment removal" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"// drop me\nconst a=1;",new_string:"const a=1;"}}')" \
+  allow
+
+# 6. .md ファイル → 対象外 allow
+run_case "markdown out of scope" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.md",old_string:"text",new_string:"<!-- note -->\ntext"}}')" \
+  allow
+
+# 7. 存在しない .ts への Write (新規ファイル) → allow
+run_case "write new file skipped" \
+  "$(jq -nc --arg p "$WORK/brand-new.ts" '{tool_name:"Write",tool_input:{file_path:$p,content:"// license header\nconst a=1;"}}')" \
+  allow
+
+# 8. C-family テンプレートリテラル (バッククォート不均衡) → allow
+run_case "unbalanced backtick guard" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"const a=1;",new_string:"const q = `\n// inside template\nSELECT 1;"}}')" \
+  allow
+
+# 9. YAML run: | block scalar 内の # → allow
+run_case "yaml block scalar guard" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/ci.yml",old_string:"steps:",new_string:"steps:\n  - run: |\n      # build step\n      make"}}')" \
+  allow
+
+# 9b. 通常の YAML コメント追加 → deny
+run_case "yaml real comment" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/c.yml",old_string:"key: 1",new_string:"# config\nkey: 1"}}')" \
+  deny
+
+# 10. .go の //go:generate → allowlist で allow
+run_case "go directive allowlisted" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.go",old_string:"package p",new_string:"package p\n//go:generate mockgen"}}')" \
+  allow
+
+# 10b. eslint-disable ディレクティブ → allow
+run_case "eslint directive allowlisted" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"const a=1;",new_string:"// eslint-disable-next-line\nconst a=1;"}}')" \
+  allow
+
+# 11. 鮮度内マーカー存在下でコメント追加 → allow
+mkdir -p "$WORK/fresh/.claude/tmp"
+: > "$WORK/fresh/.claude/tmp/.comment-guard-allow"
+run_case "fresh marker allows comment" \
+  "$(jq -nc --arg c "$WORK/fresh" '{tool_name:"Edit",cwd:$c,tool_input:{file_path:"/tmp/x.ts",old_string:"const a=1;",new_string:"// added\nconst a=1;"}}')" \
+  allow
+
+# 12. 鮮度切れマーカー (mtime 古い) 存在下でコメント追加 → deny
+mkdir -p "$WORK/stale/.claude/tmp"
+: > "$WORK/stale/.claude/tmp/.comment-guard-allow"
+touch -t 202001010000 "$WORK/stale/.claude/tmp/.comment-guard-allow"
+run_case "stale marker denies comment" \
+  "$(jq -nc --arg c "$WORK/stale" '{tool_name:"Edit",cwd:$c,tool_input:{file_path:"/tmp/x.ts",old_string:"const a=1;",new_string:"// added\nconst a=1;"}}')" \
+  deny
+
+# 13. COMMENT_GUARD=off → 常に allow
+run_case "COMMENT_GUARD=off disables guard" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.ts",old_string:"const a=1;",new_string:"// added\nconst a=1;"}}')" \
+  allow "COMMENT_GUARD=off"
+
+# 14. 不正 JSON → fail-open allow
+run_case "malformed json fails open" "not json at all" allow
+
+# 15. MultiEdit で 1 edit がコメント増 → deny
+run_case "multiedit one edit adds comment" \
+  "$(jq -nc '{tool_name:"MultiEdit",tool_input:{file_path:"/tmp/x.ts",edits:[{old_string:"a",new_string:"b"},{old_string:"c",new_string:"// note\nc"}]}}')" \
+  deny
+
+# 16. 既存 .ts への Write でコメント増 → deny
+printf 'const a=1;\n' > "$WORK/exist.ts"
+run_case "write existing file adds comment" \
+  "$(jq -nc --arg p "$WORK/exist.ts" '{tool_name:"Write",tool_input:{file_path:$p,content:"// added\nconst a=1;\n"}}')" \
+  deny
+
+# 17. 既存 .ts への Write で内容据え置き → allow
+printf '// keep\nconst a=1;\n' > "$WORK/keep.ts"
+run_case "write existing file unchanged comments" \
+  "$(jq -nc --arg p "$WORK/keep.ts" '{tool_name:"Write",tool_input:{file_path:$p,content:"// keep\nconst a=2;\n"}}')" \
+  allow
+
+# 18. Bash ツール → 対象外 allow
+run_case "bash tool out of scope" \
+  "$(jq -nc '{tool_name:"Bash",tool_input:{command:"ls"}}')" \
+  allow
+
+# 19. .sql 行コメント追加 → deny
+run_case "sql line comment added" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.sql",old_string:"SELECT 1;",new_string:"-- comment\nSELECT 1;"}}')" \
+  deny
+
+# 20. .sql ブロックコメント追加 → deny
+run_case "sql block comment added" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.sql",old_string:"SELECT 1;",new_string:"/* comment */\nSELECT 1;"}}')" \
+  deny
+
+# 21. .sql 文字列リテラル内の -- → allow
+run_case "sql dashes inside string literal" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.sql",old_string:"SELECT 1;",new_string:"SELECT * FROM t WHERE col = '\''--not a comment'\'';"}}')" \
+  allow
+
+# 22. .sql コメントなし純粋クエリ追加 → allow
+run_case "sql pure query added" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.sql",old_string:"SELECT 1;",new_string:"SELECT 1;\nSELECT 2 FROM users;"}}')" \
+  allow
+
+# 23. .sql 既存コメント削除のみ → allow
+run_case "sql comment removal" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.sql",old_string:"-- drop me\nSELECT 1;",new_string:"SELECT 1;"}}')" \
+  allow
+
+# 24. .rs 行コメント追加 → deny (rust を c-family に追加した検証)
+run_case "rust line comment added" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.rs",old_string:"let a = 1;",new_string:"// added\nlet a = 1;"}}')" \
+  deny
+
+# 25. .rs 属性 (コメントではない) 追加 → allow
+run_case "rust attribute not a comment" \
+  "$(jq -nc '{tool_name:"Edit",tool_input:{file_path:"/tmp/x.rs",old_string:"struct S;",new_string:"#[derive(Debug)]\nstruct S;"}}')" \
+  allow
+
+echo
+echo "Results: PASS=$pass FAIL=$fail"
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+echo "ALL PASS"

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -393,6 +393,17 @@
         ]
       },
       {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $HOME/.claude/scripts/policy/comment-guard.sh",
+            "timeout": 5,
+            "statusMessage": "Comment guard..."
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ CLAUDE.local.md
 .claude/channels/
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+.claude/tmp/
 
 # Machine-local zsh config
 .config/zsh/local.zsh

--- a/docs/plans/2026-06-06-comment-guard-hook-design.md
+++ b/docs/plans/2026-06-06-comment-guard-hook-design.md
@@ -1,0 +1,82 @@
+# comment-guard hook 設計メモ
+
+- **日付**: 2026-06-06
+- **状態**: 実装完了（2026-06-06、hook + test 27ケースPASS + settings.json 配線 + .gitignore）。/review PASS（Codex CLI は stdin hang で Haiku fallback）
+- **規模**: M（新規 hook 追加 = harness 変更）
+- **由来**: grill-me インタビューで設計確定。当初要望「コメントを見直す＋修正する Skill」→ MH4GF `comment-guard.sh`（`MH4GF/claude-code` repo, `user-scope/hooks/comment-guard.sh`, MIT License）参照を経て「予防 hook 特化」に収束。
+
+## 目的
+
+私（Claude）が低価値なコードコメントを乱造するのを **予防** する。
+コメントはデフォルト禁止とし、価値ある **Tier 1（ハザード/制約 = 「そうしないと何が起きるか」）** だけを意識的 override で書かせる。
+
+> ユーザーのコメント哲学: 作業経過や「なぜそうしたか（意図）」より、「そうしないと何が起きるか（結果・ハザード・制約）」を重視。経緯・意図は git commit message に置く。
+
+## コメントの価値序列（Tier）
+
+設計判断の背骨。ただし **hook 自身は Tier を判定しない**（鈍いまま）。Tier は deny メッセージのガイドと人間 override 判断に効く。
+
+| Tier | 内容 | 扱い |
+|---|---|---|
+| 1 | ハザード/制約（「逆順だと deadlock」「0 を null 扱いで残高消失」） | 最も価値が高い。書くなら意識的 override |
+| 2 | 非自明な WHY（意図） | 可能なら Tier 1（結果ベース）へ昇格させて書く |
+| 3 | 作業経過・履歴（「5月に田中追加」「前はループだった」） | 不要。commit message へ |
+| 4 | 自明コメント（`i++ // i をインクリメント`） | 不要 |
+
+## アーキテクチャ決定
+
+| 項目 | 決定 | 理由 |
+|---|---|---|
+| 形態 | **hook のみ**（PreToolUse deny）。skill は作らない | 「hook 特化」。treatment（見直す＋修正）は YAGNI 保留、低品質が出たら iterate |
+| ベース | MH4GF `comment-guard.sh` を **adapt** | 実証済み awk ロジック再利用。要ライセンス確認＋ attribution コメント |
+| 判定 | pragma 以外の **コメント純増を全 deny**（blunt）。fail-open | Tier 判定を hook に持ち込むと determinism boundary を壊す。「鈍いまま」が設計上の必然 |
+| Tier 哲学との整合 | 良い Tier 1 コメントも block される = 機能であって欠陥でない | 高価値コメントは稀であるべき。override の一手間が乱造の防波堤 |
+| 対象拡張子 | `ts tsx js jsx mjs cjs go rs` / `json` / `yaml yml py` / `sql` | MH4GF ＋ rust。**shell 除外**（dotfiles ハーネススクリプトは説明コメントが正当に価値を持つ。`comment-guard.sh` 自身の冒頭コメントが Tier 1 の好例。「ゲート/フックは冗長性必須」と自己矛盾するため） |
+| 範囲 | グローバル・**デフォルト ON**・dotfiles で git 管理 | 「どこでも低価値コメントを書かせたくない」の素直な実装。仕事リポジトリ（hearable 等）でも発火する点は承知のうえ、env で個別 OFF |
+
+## 逃げ道（escape hatch）
+
+skill を作らないので、marker を touch する主体は「私が Bash で明示」or「ユーザー手動」になる。
+
+1. **`COMMENT_GUARD=off` 環境変数** — セッション全体キルスイッチ（dotfiles でコメント作業する時など）
+2. **marker `.claude/tmp/.comment-guard-allow`**（30分有効、自然失効）— 私が Bash で `touch` する or ユーザー手動。Bash touch は tool call として **可視・監査可能**（こっそりバイパス不可）
+3. 人間ステアのフロー: 私が Tier 1 コメントを書きたい → ユーザーに「このハザードコメント書きたい、override していい？」と確認 → 承認後 touch して書く
+
+## deny メッセージ（案）
+
+> 新規コードコメントの追加はブロックされています。**経緯・意図は git commit message に書いてください**。コードに残すなら「そうしないと何が起きるか（ハザード・制約）」を書く Tier 1 コメントに限り、その場合はユーザーに確認のうえ override（`COMMENT_GUARD=off` または marker touch）してください。
+
+## 配置
+
+| 対象 | パス |
+|---|---|
+| hook script | `.config/claude/scripts/policy/comment-guard.sh` |
+| 登録 | `.config/claude/settings.json` の `PreToolUse`（matcher = `Edit\|Write\|MultiEdit`） |
+| marker | `.claude/tmp/.comment-guard-allow`（**gitignore 対象**、git 管理しない） |
+
+## hook ロジック（MH4GF 踏襲）
+
+- 入力 JSON から `tool_name` を読み、Edit/Write/MultiEdit のみ処理（他は exit 0）
+- `file_path` の拡張子で family 判定（c-family / hash / sql）。対象外拡張子は exit 0
+- `count_comments`: family ごとに文字列リテラルを除去してからコメント行をカウント。pragma（`eslint-` `@ts-` `biome-ignore` `# noqa` `# type:` `//go:` `prettier-ignore` 等）は allowlist で除外
+- `contribution`: old/new のコメント数の差分。c-family はバッククォート奇数（テンプレートリテラル途中）、hash は YAML ブロックスカラー（`|` `>`）で誤検知回避 → 0 を返す
+  - **既知の制限（fail-safe 側）**: YAML ブロックスカラーガードは `new` 全体で判定するため、同一 edit 内に `run: |` とコメント追加が混在すると、その edit のコメント増分は丸ごとスキップされ allow になる（false-negative）。allow 方向（=編集を止めない）に倒れる安全側の割り切り。同一 edit で block scalar とコメント追加が同時に起きるケースは稀。
+- 純増（total > 0）かつ marker 不在/失効 → **deny**。それ以外は exit 0（allow）
+- fail-open: 判定不能・jq エラー等はすべて exit 0
+
+## 実装時の義務（CLAUDE.md ハーネス規約）
+
+- ハーネス変更 → **Codex Review Gate（codex-reviewer + code-reviewer 並列）＋ `/review` PASS が mandatory**
+- 最低検証: `task validate-configs`, `task validate-symlinks`
+- `settings.json` 追加前に **既存 `PreToolUse` 配列を grep**（重複登録防止 — `feedback_settings_json_grep_first`）
+- hook 単体テスト:
+  - コメント純増の Edit JSON を流して `permissionDecision: deny` が出ること
+  - pragma 行（`// eslint-disable` 等）が通ること
+  - 対象外拡張子（`.md` 等）で exit 0 すること
+  - marker 存在時に allow されること
+  - `COMMENT_GUARD=off` で exit 0 すること
+
+## 保留した範囲（将来 iterate 候補）
+
+- **treatment skill**（既存・人間記述・hook 導入前コメントを Tier 序列で見直す＋修正、Tier 2→1 昇格）。当初要望だが YAGNI で保留。「低品質コメントが出てきたら改善を加える」方針
+- hook を賢くする（ハザードキーワード allowlist 等）案は **却下**。determinism boundary を崩すため

--- a/docs/plans/active/2026-06-06-plan-status-close-gate-plan.md
+++ b/docs/plans/active/2026-06-06-plan-status-close-gate-plan.md
@@ -1,0 +1,759 @@
+---
+topic: plan-status-close-gate
+status: active
+scope: L
+owner: takeuchi-shogo
+created: 2026-06-06
+artifacts: "scripts/lifecycle/plan-close-detector.py, scripts/tests/test_plan_close_detector.py, scripts/runtime/nightly/run-plan-close-scan.sh"
+asserts: "plan-close-tests"
+success_criteria: "nightly が docs/plans/active/ を走査し『lifecycle=active だが完了』候補を Tier 別に検出して docs/plan-close/ にレポート出力。Tier1(allowlisted assert 成功 + clean tree / 誤配置) のみ自動 PR 提案を生成 (直接 move/commit はしない)。calibration ledger で人間裁定の agree 率を記録し、agree≥0.9 + 安全層充足を auto-apply の開放条件とする"
+---
+
+# Plan Status Close-Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `status: active` のまま放置され「死蔵」と誤判定される完了済み plan を機械検出し、確信度 Tier 別に報告／自動クローズ提案する仕組みを作る。
+
+**Architecture:** 既存 `doc-status-audit.py` の `parse_frontmatter` を再利用した独立検出器 `plan-close-detector.py` を新設。完了シグナルを Tier に分類 — **Tier1 = allowlisted assert 成功 + clean tree、または誤配置** (→自動 PR 提案), **Tier2 = 成果物パス存在のみ / checkbox 全 done** (→報告のみ), **Tier3 = stale のみ** (→報告のみ)。nightly で dry-run scan を回し、`docs/plan-close/candidates.jsonl` を pending source of truth とする。人間が Tier1 PR を裁定した**後**に `calibration-verdict-logger.py` で agree/disagree を記録。agree 率が閾値を超え、かつ安全層 (clean tree / open PR guard / allowlist / fail-loud) を満たすまで auto-apply は開放しない (learned 昇格ループの Wave gating と同型)。
+
+**Tech Stack:** Python 3.13 (標準ライブラリのみ), bash, launchd, pytest。
+
+---
+
+## 設計上の教訓 (本セッション 2026-06-06 で実証)
+
+1. **checkbox は完了の証拠にならない** — nix-migration は checkbox 0 のまま実装完了・稼働中だった。→ checkbox は Tier2 (報告のみ) の補助シグナルに格下げ。
+2. **「書いた」≠「配線した」で死蔵する** — `run-learned-promote.sh` はスクリプト実体があるのに launchd 未登録で一度も実行されなかった。→ Task 5 で `launchd-install.sh` の `TASKS` 配列への登録を**必須ステップ**にし、登録漏れを検証する。
+3. **自動化は calibration 前に開放しない** — learned 昇格ループは無人 PR 化 (Wave3) を calibration (mechanical 0/139) の後に YAGNI 撤退した。→ auto-apply は Task 6 で実装するが、calibration で agree≥0.9 を実測するまでデフォルト無効。
+4. **「存在」≠「完了」の罠は再帰する (Codex Gate #1 で露呈)** — 初版は「成果物パス実在」を Tier1 の完了証拠に据えたが、これは教訓1と同じ罠 (途中実装でもファイルは存在する =「作成済み」であって「完了・配線・検証済み」ではない)。→ **Tier1 は allowlisted assert の成功を必須**とし、パス存在のみは Tier2 (`ARTIFACTS_PRESENT`, 報告のみ) に降格。
+5. **plan 本文をコード実行面にしない (Codex Gate #4)** — 初版の `verification: "! 任意コマンド"` (`shell=True`) は、LLM/外部記事由来の文言が混ざる plan frontmatter の任意コマンドを nightly が実行する prompt injection 経路だった。→ `! command` 形式を廃止し、detector 内の固定 allowlist map から `shell=False` で起動する `asserts:` enum に置換。
+
+> **Codex Spec/Plan Gate (2026-06-06, Verdict: REVISE) 反映済み**: 上記 4-5 に加え、(#2) quote stripping 仕様化 / (#3) `status` → `lifecycle:` 名前空間分離で doc-status-audit 語彙衝突を回避 / (#5) calibration-verdict-logger は pending queue でなく裁定記録器として正しく使用 / (#6) launchd TASKS 書式修正 / auto-apply に `run-learned-promote.sh` 安全層を縮小移植。Codex 出力: `/tmp/cmux-results/w-1780728643-codex.md`。
+
+## 撤退条件 (reversible-decisions)
+
+- **auto-apply 開放の撤退**: nightly 30 日分の calibration で Tier1 の human-agree 率 < 0.9 なら、Tier1 を「報告のみ」に降格し auto-PR を恒久無効化する (`references/reversible-decisions.md` に記録)。
+- **検出器ごと撤退**: 3 ヶ月運用して close 候補の検出が月 0 件、かつ既存 active plan の誤配置も解消済みなら、本検出器を退役し `docs/decommission-log.md` に記録する (Build to Delete)。
+
+## File Structure
+
+- `scripts/lifecycle/plan-close-detector.py` (Create) — 検出器本体。`docs/plans/active/*.md` を走査し Tier 分類した候補を JSONL + md で出力。`--apply-tier1` で Tier1 を安全層付き PR 提案として生成 (直接 move/commit はしない)。
+- `scripts/tests/test_plan_close_detector.py` (Create) — pytest。Tier 分類・asserts/artifacts 照合・誤配置検出・dry-run 不変性をカバー。
+- `scripts/runtime/nightly/run-plan-close-scan.sh` (Create) — nightly runner。検出器を dry-run で起動しレポート生成、calibration ledger に候補を emit。
+- `scripts/runtime/nightly/launchd-install.sh` (Modify) — `TASKS` 配列に `plan-close-scan` を追加。
+- `PLANS.md` (Modify) — frontmatter 規約に `lifecycle:`/`artifacts:`/`asserts:` 欄を追加 (予防レーン)。
+- `docs/plan-close/` (Create dir) — レポート出力先 (`<DATE>-close-report.md`, `candidates.jsonl`)。`.gitkeep` + `README.md`。
+- `docs/plans/active/2026-06-06-plan-status-close-gate-plan.md` (この plan 自身, dogfood: `lifecycle:`/`artifacts:`/`asserts:` 欄を保有)。
+
+---
+
+### Task 0: 予防レーン — PLANS.md / doc-status-schema.md に `artifacts:`/`asserts:`/`lifecycle:` 欄を規約化
+
+**Files:**
+- Modify: `PLANS.md` (frontmatter テンプレート節)
+- Modify: `.config/claude/references/doc-status-schema.md` (status 語彙衝突の回避を明記)
+
+**設計 (Codex Gate #1/#3/#4 反映):**
+- 完了証拠は2分割する。`artifacts:` (成果物パス = 弱い証拠 → Tier2) と `asserts:` (allowlist enum = 強い証拠 → Tier1)。
+- `status:` は doc-status-audit.py が `active/reference/archive` で使う語彙と衝突するため、plan の生存状態は **`lifecycle:`** で持つ (`active/completed/deferred/paused/pending`)。既存 plan の `status:` は移行期間中 detector が後方互換で読む (Task 3 で両対応)。
+- 任意 shell コマンド形式は**置かない**。`asserts:` は detector 内の固定 allowlist map のキーのみ。
+
+- [ ] **Step 1: PLANS.md の frontmatter テンプレートに規約を追記**
+
+`PLANS.md` のテンプレート節に以下を追加:
+
+```markdown
+### frontmatter 完了判定欄 (推奨)
+
+plan-close-detector が走査して close 候補を機械判定するための欄。simple `key: value` parser 互換 (1行・カンマ区切り、detector が outer quote を strip する)。
+
+- `lifecycle: active` — plan の生存状態 (active/completed/deferred/paused/pending)。`status:` とは別名前空間 (status は doc-status-audit の active/reference/archive 用)。
+- `artifacts: "path/a.py, path/b.sh"` — 成果物パス列挙。全実在で **Tier2 (ARTIFACTS_PRESENT, 報告のみ)**。「作成済み」の弱い証拠であり、これだけでは自動クローズしない。
+- `asserts: "validate-configs, plan-close-tests"` — detector の固定 allowlist (`ASSERTS` map) のキー列挙。全 assert が exit 0 かつ working tree clean で **Tier1 (VERIFIED_DONE, 自動 PR 提案)**。任意コマンドは書けない (allowlist 外のキーは無視)。
+
+何も書かない plan は stale + checkbox の Tier2/3 報告のみ対象。
+```
+
+- [ ] **Step 2: doc-status-schema.md に語彙分離を明記 (Codex Gate #3)**
+
+`.config/claude/references/doc-status-schema.md` に追記: 「`docs/plans/` の plan は `lifecycle:` (active/completed/deferred/paused/pending) を生存状態に使う。doc-status-audit が扱う `status:` (active/reference/archive) とは別概念で、両ツールは disjoint な責務 (doc-status-audit=reference docs の status 推定 / plan-close-detector=plans の lifecycle クローズ判定)。」
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add PLANS.md .config/claude/references/doc-status-schema.md
+git commit -m "📝 docs(plans): 完了判定欄 (lifecycle/artifacts/asserts) を規約化 + status語彙分離"
+```
+
+---
+
+### Task 1: 検出器の骨格 — frontmatter + 完了シグナル抽出
+
+**Files:**
+- Create: `scripts/lifecycle/plan-close-detector.py`
+- Test: `scripts/tests/test_plan_close_detector.py`
+
+- [ ] **Step 1: 失敗するテストを書く (シグナル抽出)**
+
+`scripts/tests/test_plan_close_detector.py`:
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lifecycle"))
+import importlib
+
+pcd = importlib.import_module("plan-close-detector")
+
+
+def _write(tmp_path, name, body):
+    f = tmp_path / name
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def test_extract_signals_reads_lifecycle_artifacts_asserts(tmp_path):
+    f = _write(
+        tmp_path,
+        "p.md",
+        "---\nlifecycle: active\nartifacts: \"a.py, b.sh\"\nasserts: \"plan-close-tests\"\n---\n\n- [x] done\n- [ ] todo\n",
+    )
+    sig = pcd.extract_signals(f)
+    assert sig.lifecycle == "active"
+    assert sig.artifacts == '"a.py, b.sh"'
+    assert sig.asserts == '"plan-close-tests"'
+    assert sig.checkboxes_total == 2
+    assert sig.checkboxes_done == 1
+
+
+def test_extract_signals_falls_back_to_status(tmp_path):
+    # 既存 plan は status: のみ。lifecycle 欠落時は status を後方互換で読む。
+    f = _write(tmp_path, "old.md", "---\nstatus: completed\n---\n# old\n")
+    assert pcd.extract_signals(f).lifecycle == "completed"
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py::test_extract_signals_reads_lifecycle_artifacts_asserts -v`
+Expected: FAIL (`ModuleNotFoundError` or `AttributeError: extract_signals`)
+
+- [ ] **Step 3: 最小実装 — extract_signals**
+
+`scripts/lifecycle/plan-close-detector.py`:
+
+```python
+#!/usr/bin/env python3
+"""plan-close-detector — detect active plans that are actually complete.
+
+Scans docs/plans/active/*.md, classifies close candidates into confidence
+tiers. Tier1 (allowlisted asserts pass + clean tree / misplaced) is auto-PR eligible;
+Tier2/3 are report-only. Default mode is dry-run (no file moves).
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACTIVE_DIR = REPO_ROOT / "docs" / "plans" / "active"
+
+# Reuse the frontmatter parser from doc-status-audit.py (DRY — no third parser).
+_audit_path = Path(__file__).resolve().parent / "doc-status-audit.py"
+_spec = importlib.util.spec_from_file_location("doc_status_audit", _audit_path)
+_audit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_audit)
+parse_frontmatter = _audit.parse_frontmatter
+
+_CHECKBOX_DONE = re.compile(r"^\s*[-*] \[x\]", re.IGNORECASE | re.MULTILINE)
+_CHECKBOX_TODO = re.compile(r"^\s*[-*] \[ \]", re.MULTILINE)
+
+
+@dataclass
+class Signals:
+    path: Path
+    lifecycle: str | None  # frontmatter lifecycle:、無ければ status: で後方互換
+    artifacts: str | None  # 成果物パス列挙 (弱い証拠)
+    asserts: str | None    # allowlist enum キー列挙 (強い証拠)
+    checkboxes_total: int
+    checkboxes_done: int
+
+
+def extract_signals(path: Path) -> Signals:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    fields, _ = parse_frontmatter(text)
+    fields = fields or {}
+    done = len(_CHECKBOX_DONE.findall(text))
+    todo = len(_CHECKBOX_TODO.findall(text))
+    return Signals(
+        path=path,
+        lifecycle=fields.get("lifecycle") or fields.get("status"),
+        artifacts=fields.get("artifacts"),
+        asserts=fields.get("asserts"),
+        checkboxes_total=done + todo,
+        checkboxes_done=done,
+    )
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py::test_extract_signals_reads_lifecycle_artifacts_asserts -v`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lifecycle/plan-close-detector.py scripts/tests/test_plan_close_detector.py
+git commit -m "✨ feat(lifecycle): plan-close-detector シグナル抽出 (frontmatter+checkbox)"
+```
+
+---
+
+### Task 2: 照合ロジック — `artifacts_present` (弱) + `asserts_satisfied` (強・allowlist)
+
+**Files:**
+- Modify: `scripts/lifecycle/plan-close-detector.py`
+- Test: `scripts/tests/test_plan_close_detector.py`
+
+**設計 (Codex Gate #2/#4):** quote stripping を明示。任意コマンド実行を排し、`ASSERTS` 固定 allowlist の `shell=False` 起動のみ。
+
+- [ ] **Step 1: 失敗するテストを書く (パス存在 / allowlist assert / quote strip / 非allowlist拒否)**
+
+`test_plan_close_detector.py` に追記:
+
+```python
+def test_artifacts_present_all_exist(tmp_path, monkeypatch):
+    (tmp_path / "a.py").write_text("x")
+    (tmp_path / "b.sh").write_text("y")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    assert pcd.artifacts_present('"a.py, b.sh"') is True  # outer quote を strip
+
+
+def test_artifacts_present_missing_one(tmp_path, monkeypatch):
+    (tmp_path / "a.py").write_text("x")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    assert pcd.artifacts_present("a.py, b.sh") is False
+
+
+def test_asserts_satisfied_allowlisted(monkeypatch):
+    # ALLOWLIST のキーを exit 0 で返すコマンドに差し替え
+    monkeypatch.setattr(pcd, "ASSERTS", {"ok": ["true"], "ng": ["false"]})
+    assert pcd.asserts_satisfied("ok") is True
+    assert pcd.asserts_satisfied("ok, ng") is False
+
+
+def test_asserts_satisfied_rejects_non_allowlisted(monkeypatch):
+    monkeypatch.setattr(pcd, "ASSERTS", {"ok": ["true"]})
+    # allowlist 外のキーは無視され、有効 assert ゼロ → False (証拠なし)
+    assert pcd.asserts_satisfied("rm -rf /") is False
+    assert pcd.asserts_satisfied("! task validate-configs") is False
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -k "artifacts or asserts" -v`
+Expected: FAIL (`AttributeError`)
+
+- [ ] **Step 3: 実装 — quote strip + artifacts_present + ASSERTS allowlist + asserts_satisfied**
+
+`plan-close-detector.py` に追記:
+
+```python
+import subprocess
+
+# Fixed allowlist: assert key → argv (shell=False で起動). plan frontmatter からは
+# キーのみ参照可能で、任意コマンドは実行できない (Codex Gate #4: prompt injection 遮断).
+ASSERTS: dict[str, list[str]] = {
+    "validate-configs": ["task", "validate-configs"],
+    "validate-symlinks": ["task", "validate-symlinks"],
+    "plan-close-tests": ["python3", "-m", "pytest",
+                         "scripts/tests/test_plan_close_detector.py", "-q"],
+}
+
+
+def _csv(field: str) -> list[str]:
+    """Strip outer quotes (Codex Gate #2) and split a comma-separated field."""
+    v = field.strip().strip('"').strip("'")
+    return [x.strip() for x in v.split(",") if x.strip()]
+
+
+def artifacts_present(artifacts: str) -> bool:
+    """Weak signal: all declared artifact paths exist. None/empty → False."""
+    paths = _csv(artifacts)
+    return bool(paths) and all((REPO_ROOT / p).exists() for p in paths)
+
+
+def asserts_satisfied(asserts: str) -> bool:
+    """Strong signal: every allowlisted assert key exits 0 (shell=False).
+
+    Keys not in ASSERTS are ignored. If no valid assert remains → False."""
+    keys = [k for k in _csv(asserts) if k in ASSERTS]
+    if not keys:
+        return False
+    for k in keys:
+        try:
+            rc = subprocess.run(
+                ASSERTS[k], cwd=REPO_ROOT, timeout=120,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            ).returncode
+        except (subprocess.SubprocessError, OSError):
+            return False
+        if rc != 0:
+            return False
+    return True
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -k "artifacts or asserts" -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lifecycle/plan-close-detector.py scripts/tests/test_plan_close_detector.py
+git commit -m "✨ feat(lifecycle): artifacts_present + asserts_satisfied (allowlist, shell=False)"
+```
+
+---
+
+### Task 3: Tier 分類
+
+**Files:**
+- Modify: `scripts/lifecycle/plan-close-detector.py`
+- Test: `scripts/tests/test_plan_close_detector.py`
+
+分類規則 (`classify(signals, stale_days, tree_clean, stale_threshold=30)`)。`tree_clean` は対象 plan の成果物に未コミット変更が無いか (scan が `git diff --quiet` で算出して渡す):
+
+| 結果 | 条件 | Tier | 自動 PR |
+|---|---|---|---|
+| `MISPLACED` | lifecycle ∈ {completed, archive, deferred, done, paused} かつ active/ に存在 | 1 | ○ |
+| `VERIFIED_DONE` | lifecycle=active かつ **asserts 充足** かつ **tree_clean** | 1 | ○ |
+| `ARTIFACTS_PRESENT` | lifecycle=active かつ artifacts 全実在 (パスのみ=弱証拠) | 2 | × |
+| `LIKELY_DONE` | lifecycle=active, asserts/artifacts 無, stale≥閾値, checkbox 総数>0 かつ 全 done | 2 | × |
+| `STALE` | lifecycle=active, stale≥閾値, 上記いずれにも該当せず | 3 | × |
+| `HEALTHY` | それ以外 | — | × |
+
+> **Codex Gate #1**: パス存在のみは「作成済み」の弱証拠 → 必ず Tier2 (報告のみ)。Tier1 (自動 PR) は allowlisted assert の exit 0 + clean tree を要求し、途中実装の誤クローズを構造的に防ぐ。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```python
+def test_classify_misplaced():
+    s = pcd.Signals(path=Path("docs/plans/active/x.md"), lifecycle="completed",
+                    artifacts=None, asserts=None, checkboxes_total=0, checkboxes_done=0)
+    v = pcd.classify(s, stale_days=5, tree_clean=True)
+    assert v.result == "MISPLACED" and v.tier == 1
+
+
+def test_classify_verified_done_requires_assert_and_clean_tree(monkeypatch):
+    monkeypatch.setattr(pcd, "ASSERTS", {"ok": ["true"]})
+    s = pcd.Signals(path=Path("x.md"), lifecycle="active", artifacts=None,
+                    asserts="ok", checkboxes_total=3, checkboxes_done=0)
+    assert pcd.classify(s, stale_days=1, tree_clean=True).result == "VERIFIED_DONE"
+    # dirty tree → Tier1 不可 (HEALTHY に落ちる)
+    assert pcd.classify(s, stale_days=1, tree_clean=False).result == "HEALTHY"
+
+
+def test_classify_artifacts_present_is_tier2(monkeypatch, tmp_path):
+    (tmp_path / "a.py").write_text("x")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    s = pcd.Signals(path=Path("x.md"), lifecycle="active", artifacts="a.py",
+                    asserts=None, checkboxes_total=3, checkboxes_done=0)
+    v = pcd.classify(s, stale_days=1, tree_clean=True)
+    assert v.result == "ARTIFACTS_PRESENT" and v.tier == 2
+
+
+def test_classify_likely_done_is_tier2():
+    s = pcd.Signals(path=Path("x.md"), lifecycle="active", artifacts=None,
+                    asserts=None, checkboxes_total=4, checkboxes_done=4)
+    v = pcd.classify(s, stale_days=40, tree_clean=True)
+    assert v.result == "LIKELY_DONE" and v.tier == 2
+
+
+def test_classify_healthy_recent():
+    s = pcd.Signals(path=Path("x.md"), lifecycle="active", artifacts=None,
+                    asserts=None, checkboxes_total=4, checkboxes_done=1)
+    assert pcd.classify(s, stale_days=3, tree_clean=True).result == "HEALTHY"
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -k classify -v`
+Expected: FAIL (`AttributeError: classify`)
+
+- [ ] **Step 3: 実装 — classify**
+
+`plan-close-detector.py` に追記:
+
+```python
+STALE_THRESHOLD_DAYS = 30
+_CLOSED_LIFECYCLES = {"completed", "archive", "deferred", "done", "paused"}
+
+
+@dataclass
+class Verdict:
+    result: str
+    tier: int  # 0 = none
+
+
+def classify(signals: Signals, stale_days: int, tree_clean: bool,
+             stale_threshold: int = STALE_THRESHOLD_DAYS) -> Verdict:
+    s = signals
+    if s.lifecycle in _CLOSED_LIFECYCLES:
+        return Verdict("MISPLACED", 1)
+    if s.lifecycle != "active":
+        return Verdict("HEALTHY", 0)
+    # Tier1: 強証拠 (allowlisted assert 成功) かつ working tree clean のみ
+    if s.asserts and asserts_satisfied(s.asserts) and tree_clean:
+        return Verdict("VERIFIED_DONE", 1)
+    # Tier2: 弱証拠 (成果物パス存在) — 報告のみ
+    if s.artifacts and artifacts_present(s.artifacts):
+        return Verdict("ARTIFACTS_PRESENT", 2)
+    if (not s.asserts and not s.artifacts and stale_days >= stale_threshold
+            and s.checkboxes_total > 0 and s.checkboxes_done == s.checkboxes_total):
+        return Verdict("LIKELY_DONE", 2)
+    if stale_days >= stale_threshold:
+        return Verdict("STALE", 3)
+    return Verdict("HEALTHY", 0)
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -k classify -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lifecycle/plan-close-detector.py scripts/tests/test_plan_close_detector.py
+git commit -m "✨ feat(lifecycle): Tier 分類 (Tier1=assert+clean tree, パス存在は Tier2 降格)"
+```
+
+---
+
+### Task 4: scan エントリポイント + git stale + レポート出力
+
+**Files:**
+- Modify: `scripts/lifecycle/plan-close-detector.py`
+- Test: `scripts/tests/test_plan_close_detector.py`
+- Create: `docs/plan-close/.gitkeep`, `docs/plan-close/README.md`
+
+- [ ] **Step 1: git stale 日数ヘルパのテストを書く**
+
+```python
+def test_git_stale_days_handles_untracked(tmp_path, monkeypatch):
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    f = tmp_path / "x.md"
+    f.write_text("---\nstatus: active\n---\n")
+    # untracked file: git log returns empty → fall back to mtime (0 days)
+    assert pcd.git_stale_days(f) >= 0
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -k stale -v`
+Expected: FAIL (`AttributeError: git_stale_days`)
+
+- [ ] **Step 3: 実装 — git_stale_days + scan + render_report + main**
+
+`plan-close-detector.py` に追記:
+
+```python
+import argparse
+import json
+from datetime import datetime, timezone
+
+
+def git_stale_days(path: Path) -> int:
+    """Days since last commit touching path; falls back to mtime if untracked."""
+    try:
+        out = subprocess.run(
+            ["git", "log", "-1", "--format=%cI", "--", str(path)],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        out = ""
+    if out:
+        last = datetime.fromisoformat(out)
+        return (datetime.now(timezone.utc) - last).days
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        return (datetime.now(timezone.utc) - mtime).days
+    except OSError:
+        return 0
+
+
+def tree_clean_for(artifacts: str | None) -> bool:
+    """True if declared artifact paths have no uncommitted changes (Codex Gate)."""
+    paths = _csv(artifacts) if artifacts else []
+    if not paths:
+        return True  # 成果物宣言が無ければ tree 条件は中立 (Tier1 は asserts 側で律速)
+    try:
+        rc = subprocess.run(["git", "diff", "--quiet", "--", *paths],
+                            cwd=REPO_ROOT, timeout=30).returncode
+        rc2 = subprocess.run(["git", "diff", "--cached", "--quiet", "--", *paths],
+                             cwd=REPO_ROOT, timeout=30).returncode
+        return rc == 0 and rc2 == 0
+    except (subprocess.SubprocessError, OSError):
+        return False  # 判定不能なら clean とみなさない (fail-safe: Tier1 に上げない)
+
+
+def scan(active_dir: Path = ACTIVE_DIR) -> list[dict]:
+    rows = []
+    for f in sorted(active_dir.glob("*.md")):
+        sig = extract_signals(f)
+        stale = git_stale_days(f)
+        verdict = classify(sig, stale, tree_clean=tree_clean_for(sig.artifacts))
+        if verdict.tier == 0:
+            continue
+        rows.append({
+            "file": str(f.relative_to(REPO_ROOT)),
+            "result": verdict.result,
+            "tier": verdict.tier,
+            "lifecycle": sig.lifecycle,
+            "artifacts": sig.artifacts,
+            "asserts": sig.asserts,
+            "checkboxes": f"{sig.checkboxes_done}/{sig.checkboxes_total}",
+            "stale_days": stale,
+        })
+    return rows
+
+
+def render_report(rows: list[dict], today: str) -> str:
+    lines = [f"# Plan close-candidate report — {today}", ""]
+    for tier in (1, 2, 3):
+        group = [r for r in rows if r["tier"] == tier]
+        label = {1: "Tier1 (auto-PR 対象)", 2: "Tier2 (報告のみ)",
+                 3: "Tier3 (stale のみ)"}[tier]
+        lines.append(f"## {label} — {len(group)} 件")
+        for r in group:
+            lines.append(f"- `{r['file']}` — {r['result']} "
+                         f"(lifecycle={r['lifecycle']}, checkbox={r['checkboxes']}, "
+                         f"stale={r['stale_days']}d)")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply-tier1", action="store_true",
+                    help="Tier1 候補を安全層付き PR 提案として生成 (calibration 後のみ、直接 move しない)")
+    ap.add_argument("--out", default=str(REPO_ROOT / "docs" / "plan-close"))
+    args = ap.parse_args()
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    rows = scan()
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"{today}-close-report.md").write_text(
+        render_report(rows, today), encoding="utf-8")
+    with (out_dir / "candidates.jsonl").open("a", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps({**r, "scanned": today}, ensure_ascii=False) + "\n")
+    if args.apply_tier1:
+        # Gated: implemented in Task 6, no-op until calibration opens it.
+        raise SystemExit("--apply-tier1 is gated; see Task 5/6 calibration milestone")
+    print(f"scanned: {len(rows)} candidates → {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: テストが通ることを確認 + 全テスト**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -v`
+Expected: PASS (全件)
+
+- [ ] **Step 5: docs/plan-close/ を作成**
+
+```bash
+mkdir -p docs/plan-close
+printf '# plan-close レポート出力先\n\nplan-close-detector の dry-run scan 出力 (`<DATE>-close-report.md`, `candidates.jsonl`)。\nTier1 候補のみ将来 auto-PR 対象。Tier2/3 は人間がクローズ判断する。\n' > docs/plan-close/README.md
+touch docs/plan-close/.gitkeep
+```
+
+- [ ] **Step 6: 実 active/ に対して dry-run 実行 (dogfood)**
+
+Run: `python3 scripts/lifecycle/plan-close-detector.py`
+Expected: `docs/plan-close/<today>-close-report.md` 生成。誤配置 (skill-guide-absorb=completed が active/) が MISPLACED (Tier1) に出ること、本 plan は asserts(plan-close-tests) 未通過のため VERIFIED_DONE にはならず ARTIFACTS_PRESENT(Tier2) 止まりであることを目視確認。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add scripts/lifecycle/plan-close-detector.py scripts/tests/test_plan_close_detector.py docs/plan-close/
+git commit -m "✨ feat(lifecycle): scan エントリポイント + git stale + レポート出力"
+```
+
+---
+
+### Task 5: nightly 配線 + calibration ledger (教訓2・3)
+
+**Files:**
+- Create: `scripts/runtime/nightly/run-plan-close-scan.sh`
+- Modify: `scripts/runtime/nightly/launchd-install.sh` (`TASKS` 配列)
+- 再利用: `scripts/learner/calibration-verdict-logger.py` (auto-triage で構築済み)
+
+- [ ] **Step 1: nightly runner を作成**
+
+`scripts/runtime/nightly/run-plan-close-scan.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+REPO="${DOTFILES_DIR:-$HOME/dotfiles}"
+cd "$REPO"
+LOG="$HOME/.claude/agent-memory/logs/plan-close-scan.log"
+mkdir -p "$(dirname "$LOG")"
+echo "[$(date -u +%FT%TZ)] plan-close-scan start" >>"$LOG"
+# dry-run のみ (auto-apply は calibration milestone まで開放しない)
+python3 scripts/lifecycle/plan-close-detector.py >>"$LOG" 2>&1
+echo "[$(date -u +%FT%TZ)] plan-close-scan done" >>"$LOG"
+```
+
+```bash
+chmod +x scripts/runtime/nightly/run-plan-close-scan.sh
+```
+
+- [ ] **Step 2: launchd の TASKS 配列に登録 (教訓2: 配線漏れ防止)**
+
+`scripts/runtime/nightly/launchd-install.sh` の `TASKS` 配列 (現状 8 件) に追加。**書式は `task|hour|minute|script` (Codex Gate #6 で確認済み — 初版の `task|script|hour|minute` は誤り)**:
+
+```bash
+  "plan-close-scan|0|50|run-plan-close-scan.sh"   # 毎日 00:50
+```
+
+(保存前に `launchd-install.sh:13` 付近の既存エントリ書式を Read して目視照合すること。)
+
+- [ ] **Step 3: 配線を検証 (教訓2)**
+
+```bash
+bash scripts/runtime/nightly/launchd-install.sh
+launchctl list | grep plan-close-scan
+```
+
+Expected: `com.user.nightly.plan-close-scan` が一覧に出る (last exit = 0 or -)。出なければ TASKS 書式ミス → 修正。
+
+- [ ] **Step 4: pending source of truth と calibration の役割分担 (Codex Gate #5)**
+
+`calibration-verdict-logger.py` は「裁定記録器」であって pending queue ではない。したがって:
+- **pending source of truth は `docs/plan-close/candidates.jsonl`** (scan が append、Tier1 候補を含む)。runner はここに書くだけで、logger は呼ばない。
+- **人間が Tier1 PR をレビューして agree/disagree を出した後**にのみ `calibration-verdict-logger.py` で裁定を記録する (auto-triage と同じ使い方。`--help` と auto-triage runner の呼び出し例を grep して引数を確定)。
+- これにより「自動が pending を作る」と「人間が裁定を記録する」が分離され、logger を pending emit に誤用しない。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/runtime/nightly/run-plan-close-scan.sh scripts/runtime/nightly/launchd-install.sh
+git commit -m "🔧 chore(nightly): plan-close-scan を launchd 配線 + calibration ledger 連携"
+```
+
+---
+
+### Task 6: auto-apply (Tier1) — **calibration milestone まで gated**
+
+**前提ゲート (教訓3):** Task 5 の nightly を最低 30 日運用し、`calibration-verdict-logger` の Tier1 human-agree 率 ≥ 0.9 を実測してから本 Task に着手する。未達なら撤退条件に従い Tier1 を報告のみに降格 (本 Task を破棄)。
+
+**Files:**
+- Modify: `scripts/lifecycle/plan-close-detector.py` (`--apply-tier1` の no-op を実装に置換)
+- Test: `scripts/tests/test_plan_close_detector.py`
+
+**安全層 (Codex Gate: `run-learned-promote.sh` から縮小移植)。auto-apply は直接 move/commit せず、必ず PR 提案に固定する:**
+1. **preflight (fail-loud)**: global working tree が clean でなければ即 abort (途中作業に割り込まない)。
+2. **open PR guard**: 既存の plan-close PR (ブランチ `plan-close/<date>` or ラベル) があれば新規作成しない。
+3. **allowlist stage**: 移動対象は Tier1 候補 (MISPLACED/VERIFIED_DONE) のみ。Tier2/3 は絶対に触らない。
+4. **dry-run diff 出力**: PR body に move 計画と各候補の根拠 (lifecycle/asserts 結果/stale) を必ず含める。
+5. **PR 経由のみ**: 専用ブランチで git mv + frontmatter 書換 → push → PR。master へ直接 commit/move しない (人間 merge が最後の砦)。
+
+- [ ] **Step 1: 失敗するテストを書く (move 計画生成。実 git 操作は dry_run で抑止)**
+
+```python
+def test_plan_moves_misplaced_to_correct_dir(tmp_path, monkeypatch):
+    active = tmp_path / "docs/plans/active"
+    active.mkdir(parents=True)
+    (active / "x.md").write_text("---\nlifecycle: deferred\n---\n# x\n")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(pcd, "ACTIVE_DIR", active)
+    moves = pcd.plan_moves()  # 計画のみ、git 操作なし
+    assert any(m["to"].endswith("paused/x.md") and m["result"] == "MISPLACED"
+               for m in moves)
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -k moves -v`
+Expected: FAIL (`AttributeError: plan_moves`)
+
+- [ ] **Step 3: 実装 — plan_moves (純粋計画) + apply_via_pr (副作用は PR のみ)**
+
+```python
+_LIFECYCLE_TO_DIR = {"completed": "completed", "archive": "completed",
+                     "done": "completed", "deferred": "paused", "paused": "paused"}
+
+
+def plan_moves() -> list[dict]:
+    """Pure planner: Tier1 候補の move 計画を返す (git 操作なし、テスト可能)."""
+    moves = []
+    for f in sorted(ACTIVE_DIR.glob("*.md")):
+        sig = extract_signals(f)
+        verdict = classify(sig, git_stale_days(f), tree_clean=tree_clean_for(sig.artifacts))
+        if verdict.tier != 1:
+            continue
+        if verdict.result == "MISPLACED":
+            dest_dir = _LIFECYCLE_TO_DIR.get(sig.lifecycle or "", "completed")
+            new_lifecycle = sig.lifecycle
+        else:  # VERIFIED_DONE
+            dest_dir, new_lifecycle = "completed", "completed"
+        moves.append({
+            "from": str(f.relative_to(REPO_ROOT)),
+            "to": f"docs/plans/{dest_dir}/{f.name}",
+            "result": verdict.result,
+            "new_lifecycle": new_lifecycle,
+            "rationale": f"{verdict.result}: lifecycle={sig.lifecycle}, asserts={sig.asserts}",
+        })
+    return moves
+
+
+def apply_via_pr() -> int:
+    """安全層付き auto-apply: preflight → 専用ブランチで move → PR 提案。直接 commit しない."""
+    # 1. preflight: global tree clean (fail-loud)
+    if subprocess.run(["git", "diff", "--quiet"], cwd=REPO_ROOT).returncode != 0:
+        raise SystemExit("[plan-close] working tree dirty; abort (preflight)")
+    moves = plan_moves()
+    if not moves:
+        print("[plan-close] no Tier1 candidates")
+        return 0
+    # 2. open PR guard / 3. branch (実装時に pr-review-*.sh の既存パターンを参照)
+    #    branch=plan-close/<date>、既存 open PR があれば skip。
+    # 4-5. branch 上で git mv + write_frontmatter → push → gh pr create。
+    #    PR body に moves (rationale 込み) を埋め込む。詳細手順は実装時に
+    #    scripts/runtime/pr-review-*.sh を Read して合わせる。
+    raise SystemExit("apply_via_pr: PR 化手順は pr-review-*.sh パターンで実装する (calibration 後)")
+```
+
+`main()` の `--apply-tier1` 分岐を `apply_via_pr()` 呼び出しに置換する。
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `python3 -m pytest scripts/tests/test_plan_close_detector.py -v`
+Expected: PASS (全件)
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lifecycle/plan-close-detector.py scripts/tests/test_plan_close_detector.py
+git commit -m "✨ feat(lifecycle): Tier1 auto-apply を安全層付き PR 提案に限定 (直接move禁止)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage**: 予防 (Task 0 verification 規約) / 検出 (Task 1-4) / 棚卸し (Task 4 Step 6 dogfood scan) / 自動 PR (Task 6, gated) / 配線 (Task 5) / calibration (Task 5 Step 4) — ユーザー選択「両方フル + 自動 PR」を全てカバー。
+- **教訓の反映**: checkbox 格下げ (Task 3 で Tier2 限定) / launchd 登録必須 (Task 5 Step 2-3) / calibration gate (Task 6 前提) — 3 件とも task 化済み。
+- **型整合**: `Signals`(lifecycle/artifacts/asserts) / `Verdict` dataclass、`extract_signals`/`artifacts_present`/`asserts_satisfied`/`classify`(tree_clean 引数)/`scan`/`tree_clean_for`/`git_stale_days`/`plan_moves`/`apply_via_pr` のシグネチャは全 task で一貫。
+- **既知の未確定点 (実装時に確定)**: Task 5 Step 4 の `calibration-verdict-logger.py` インターフェースは `--help` で確定する (現時点で内部未読のため疑似コードにせず手順で明示)。Task 6 の PR 化は既存 `pr-review-*.sh` パターンに合わせる。


### PR DESCRIPTION
## Summary
- 低価値コードコメント（作業経過・自明・意図）の乱造を**予防**する PreToolUse(deny) hook を追加。コメントはデフォルト禁止とし、Tier1（ハザード/制約=「そうしないと何が起きるか」）だけを意識的 override で書かせる。
- 判定は **blunt**（hook は Tier を判定せず、pragma 以外のコメント純増を一律 deny）。Tier 判定を hook に持ち込むと determinism boundary を壊すため「鈍いまま」が設計上の必然。
- **fail-open**: 判定不能・対象外・jq/awk エラーはすべて allow（編集を止めない）。escape hatch: `COMMENT_GUARD=off` / marker `.claude/tmp/.comment-guard-allow`（30分失効、Bash touch で可視・監査可能）。
- 対象: `ts/tsx/js/jsx/mjs/cjs/go/rs/json/yaml/yml/py/sql`。shell(.sh)は意図的に除外（ハーネススクリプトの説明コメントは正当な価値を持つため）。
- コアロジックは MH4GF/claude-code (MIT) の実証済み awk を adapt（rust を c-family に追加 / deny メッセージを Tier 哲学に差し替え / attribution 付与）。

設計: `docs/plans/2026-06-06-comment-guard-hook-design.md`

## Test plan
- [x] 単体テスト 27 ケース全 PASS（`test-comment-guard.sh`: コメント純増 deny / pragma 通過 / 対象外拡張子 / marker fresh-stale / `COMMENT_GUARD=off` / 不正JSON fail-open / Edit・Write・MultiEdit / rust）
- [x] `/review` PASS（Critical/MUST 0件。**Codex CLI は HEREDOC stdin hang で到達不可 → Haiku fallback**。既知の指摘1件: YAML block scalar ガードが同一 edit 内コメント混在を見逃す=fail-safe 側、設計ドキュメントに明記済み）
- [x] `task validate-configs` PASS / settings.json valid JSON / `bash -n` 構文 OK
- [ ] マージ後、実際の編集操作で deny/allow 挙動を確認（hook は merge 後に有効化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)