### PR TITLE
✨ feat(lifecycle): plan-status close-gate 検出器 (active 放置の完了 plan を Tier 別検出)

### DIFF
--- a/.config/claude/references/doc-status-schema.md
+++ b/.config/claude/references/doc-status-schema.md
@@ -56,6 +56,15 @@ superseded_by: "path/to/new.md"          # archive 時のみ
 - frontmatter あり + status 未設定 → status + last_reviewed のみ追加
 - frontmatter あり + status あり → 何もしない（既存尊重）
 
+## plans の `lifecycle:` との語彙分離
+
+`docs/plans/` の plan は `lifecycle:` (active/completed/deferred/paused/pending) を生存状態に使う。これは doc-status-audit が扱う `status:` (active/reference/archive) とは**別概念**で、両ツールは disjoint な責務を持つ:
+
+- **doc-status-audit** (`status:`) = reference docs の鮮度 status 推定 (active/reference/archive)
+- **plan-close-detector** (`lifecycle:`) = plans の lifecycle クローズ判定 (active のまま放置された完了 plan の検出)
+
+`status:` を plan の close 判定に流用しない (語彙衝突を避ける)。移行期間中、既存 plan の `status:` のみのものは plan-close-detector が後方互換で読む。
+
 ## 運用頻度
 
 - 月次 `/improve` 実行時に `doc-status-audit.py --dry-run` を回して新規未設定ファイルを検出

--- a/PLANS.md
+++ b/PLANS.md
@@ -77,6 +77,16 @@ success_criteria: "1行で書ける検証可能な完了条件（任意、comple
 - 並列で別 task を進めるときは worktree で filesystem を分離する
 - frontmatter に `success_criteria:` を 1 行で書くと `.config/claude/scripts/policy/completion-gate.py` が Ralph Loop 継続時に参照する (任意)。本文の `## Success Criteria` は required、frontmatter は optional な補助索引。
 
+### frontmatter 完了判定欄 (推奨)
+
+plan-close-detector (`scripts/lifecycle/plan-close-detector.py`) が走査して close 候補を機械判定するための欄。simple `key: value` parser 互換 (1行・カンマ区切り、detector が outer quote を strip する)。
+
+- `lifecycle: active` — plan の生存状態 (active/completed/deferred/paused/pending)。`status:` とは別名前空間 (status は doc-status-audit の active/reference/archive 用)。
+- `artifacts: "path/a.py, path/b.sh"` — 成果物パス列挙。全実在で **Tier2 (ARTIFACTS_PRESENT, 報告のみ)**。「作成済み」の弱い証拠であり、これだけでは自動クローズしない。
+- `asserts: "validate-configs, plan-close-tests"` — detector の固定 allowlist (`ASSERTS` map) のキー列挙。全 assert が exit 0 かつ working tree clean で **Tier1 (VERIFIED_DONE, 自動 PR 提案)**。任意コマンドは書けない (allowlist 外のキーは無視)。
+
+何も書かない plan は stale + checkbox の Tier2/3 報告のみ対象。
+
 ## Compound Plan Ceiling
 
 Skill Graphs 2.0 ([docs/research/2026-04-23-skill-graphs-2.0-absorb-analysis.md](docs/research/2026-04-23-skill-graphs-2.0-absorb-analysis.md)) の実証と $0.9^n$ の指数減衰モデルから、compound skill / plan の Success Criteria は **≤ 8 molecules (step)** を推奨する。9 step 以上は以下のいずれかを選ぶ:

--- a/docs/plan-close/.gitignore
+++ b/docs/plan-close/.gitignore
@@ -1,0 +1,2 @@
+*-close-report.md
+candidates.jsonl

--- a/docs/plan-close/README.md
+++ b/docs/plan-close/README.md
@@ -1,0 +1,4 @@
+# plan-close レポート出力先
+
+plan-close-detector の dry-run scan 出力 (`<DATE>-close-report.md`, `candidates.jsonl`)。
+Tier1 候補のみ将来 auto-PR 対象。Tier2/3 は人間がクローズ判断する。

--- a/scripts/lifecycle/plan-close-detector.py
+++ b/scripts/lifecycle/plan-close-detector.py
@@ -248,6 +248,67 @@ def render_report(rows: list[dict], today: str) -> str:
     return "\n".join(lines)
 
 
+_LIFECYCLE_TO_DIR = {
+    "completed": "completed",
+    "archive": "completed",
+    "done": "completed",
+    "deferred": "paused",
+    "paused": "paused",
+}
+
+
+def plan_moves() -> list[dict]:
+    """Pure planner: return the move plan for Tier1 candidates (no git side effects).
+
+    Kept side-effect-free so the move targets can be unit-tested without
+    touching the index or working tree.
+    """
+    moves = []
+    for f in sorted(ACTIVE_DIR.glob("*.md")):
+        sig = extract_signals(f)
+        verdict = classify(
+            sig, git_stale_days(f), tree_clean=tree_clean_for(sig.artifacts)
+        )
+        if verdict.tier != 1:
+            continue
+        if verdict.result == "MISPLACED":
+            dest_dir = _LIFECYCLE_TO_DIR.get(sig.lifecycle or "", "completed")
+            new_lifecycle = sig.lifecycle
+        else:
+            dest_dir, new_lifecycle = "completed", "completed"
+        moves.append(
+            {
+                "from": str(f.relative_to(REPO_ROOT)),
+                "to": f"docs/plans/{dest_dir}/{f.name}",
+                "result": verdict.result,
+                "new_lifecycle": new_lifecycle,
+                "rationale": (
+                    f"{verdict.result}: lifecycle={sig.lifecycle}, "
+                    f"asserts={sig.asserts}"
+                ),
+            }
+        )
+    return moves
+
+
+def apply_via_pr() -> int:
+    """Safety-layered auto-apply: preflight, then move on a branch and open a PR.
+
+    This never commits or moves on the current branch directly: a human merge
+    of the PR is the final gate. The actual PR creation stays disabled until
+    the 30-day calibration milestone proves a Tier1 human-agree rate >= 0.9.
+    """
+    if subprocess.run(["git", "diff", "--quiet"], cwd=REPO_ROOT).returncode != 0:
+        raise SystemExit("[plan-close] working tree dirty; abort (preflight)")
+    moves = plan_moves()
+    if not moves:
+        print("[plan-close] no Tier1 candidates")
+        return 0
+    raise SystemExit(
+        "apply_via_pr: PR 化手順は pr-review-*.sh パターンで実装する (calibration 後)"
+    )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument(
@@ -268,7 +329,7 @@ def main() -> int:
         for r in rows:
             fh.write(json.dumps({**r, "scanned": today}, ensure_ascii=False) + "\n")
     if args.apply_tier1:
-        raise SystemExit("--apply-tier1 is gated; see Task 5/6 calibration milestone")
+        return apply_via_pr()
     print(f"scanned: {len(rows)} candidates → {out_dir}")
     return 0
 

--- a/scripts/lifecycle/plan-close-detector.py
+++ b/scripts/lifecycle/plan-close-detector.py
@@ -8,10 +8,13 @@ eligible; Tier2/3 are report-only. Default mode is dry-run (no file moves).
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
+import json
 import re
 import subprocess
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -154,3 +157,121 @@ def classify(
     if stale_days >= stale_threshold:
         return Verdict("STALE", 3)
     return Verdict("HEALTHY", 0)
+
+
+def git_stale_days(path: Path) -> int:
+    """Days since the last commit touching path; falls back to mtime if untracked."""
+    try:
+        out = subprocess.run(
+            ["git", "log", "-1", "--format=%cI", "--", str(path)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        out = ""
+    if out:
+        last = datetime.fromisoformat(out)
+        return (datetime.now(timezone.utc) - last).days
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        return (datetime.now(timezone.utc) - mtime).days
+    except OSError:
+        return 0
+
+
+def tree_clean_for(artifacts: str | None) -> bool:
+    """True if the declared artifact paths have no uncommitted changes.
+
+    When no artifacts are declared the tree condition is neutral (True) and
+    Tier1 is gated by asserts instead. If git cannot be queried, return False
+    as a fail-safe so an undeterminable state never gets promoted to Tier1.
+    """
+    paths = _csv(artifacts) if artifacts else []
+    if not paths:
+        return True
+    try:
+        rc = subprocess.run(
+            ["git", "diff", "--quiet", "--", *paths], cwd=REPO_ROOT, timeout=30
+        ).returncode
+        rc2 = subprocess.run(
+            ["git", "diff", "--cached", "--quiet", "--", *paths],
+            cwd=REPO_ROOT,
+            timeout=30,
+        ).returncode
+        return rc == 0 and rc2 == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def scan(active_dir: Path = ACTIVE_DIR) -> list[dict]:
+    rows = []
+    for f in sorted(active_dir.glob("*.md")):
+        sig = extract_signals(f)
+        stale = git_stale_days(f)
+        verdict = classify(sig, stale, tree_clean=tree_clean_for(sig.artifacts))
+        if verdict.tier == 0:
+            continue
+        rows.append(
+            {
+                "file": str(f.relative_to(REPO_ROOT)),
+                "result": verdict.result,
+                "tier": verdict.tier,
+                "lifecycle": sig.lifecycle,
+                "artifacts": sig.artifacts,
+                "asserts": sig.asserts,
+                "checkboxes": f"{sig.checkboxes_done}/{sig.checkboxes_total}",
+                "stale_days": stale,
+            }
+        )
+    return rows
+
+
+def render_report(rows: list[dict], today: str) -> str:
+    lines = [f"# Plan close-candidate report — {today}", ""]
+    for tier in (1, 2, 3):
+        group = [r for r in rows if r["tier"] == tier]
+        label = {
+            1: "Tier1 (auto-PR 対象)",
+            2: "Tier2 (報告のみ)",
+            3: "Tier3 (stale のみ)",
+        }[tier]
+        lines.append(f"## {label} — {len(group)} 件")
+        for r in group:
+            lines.append(
+                f"- `{r['file']}` — {r['result']} "
+                f"(lifecycle={r['lifecycle']}, checkbox={r['checkboxes']}, "
+                f"stale={r['stale_days']}d)"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--apply-tier1",
+        action="store_true",
+        help="Tier1 候補を PR 提案として生成 (calibration 後のみ、直接 move しない)",
+    )
+    ap.add_argument("--out", default=str(REPO_ROOT / "docs" / "plan-close"))
+    args = ap.parse_args()
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    rows = scan()
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"{today}-close-report.md").write_text(
+        render_report(rows, today), encoding="utf-8"
+    )
+    with (out_dir / "candidates.jsonl").open("a", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps({**r, "scanned": today}, ensure_ascii=False) + "\n")
+    if args.apply_tier1:
+        raise SystemExit("--apply-tier1 is gated; see Task 5/6 calibration milestone")
+    print(f"scanned: {len(rows)} candidates → {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lifecycle/plan-close-detector.py
+++ b/scripts/lifecycle/plan-close-detector.py
@@ -109,3 +109,48 @@ def asserts_satisfied(asserts: str) -> bool:
         if rc != 0:
             return False
     return True
+
+
+STALE_THRESHOLD_DAYS = 30
+_CLOSED_LIFECYCLES = {"completed", "archive", "deferred", "done", "paused"}
+
+
+@dataclass
+class Verdict:
+    result: str
+    tier: int
+
+
+def classify(
+    signals: Signals,
+    stale_days: int,
+    tree_clean: bool,
+    stale_threshold: int = STALE_THRESHOLD_DAYS,
+) -> Verdict:
+    """Classify a plan into a close-candidate tier.
+
+    Tier1 (auto-PR eligible) requires either a misplaced lifecycle or a strong
+    completion signal (allowlisted asserts pass AND a clean working tree). Path
+    existence alone is only weak evidence (an in-progress file also exists), so
+    it stays Tier2 to structurally prevent closing partially-done plans.
+    """
+    s = signals
+    if s.lifecycle in _CLOSED_LIFECYCLES:
+        return Verdict("MISPLACED", 1)
+    if s.lifecycle != "active":
+        return Verdict("HEALTHY", 0)
+    if s.asserts and asserts_satisfied(s.asserts) and tree_clean:
+        return Verdict("VERIFIED_DONE", 1)
+    if s.artifacts and artifacts_present(s.artifacts):
+        return Verdict("ARTIFACTS_PRESENT", 2)
+    if (
+        not s.asserts
+        and not s.artifacts
+        and stale_days >= stale_threshold
+        and s.checkboxes_total > 0
+        and s.checkboxes_done == s.checkboxes_total
+    ):
+        return Verdict("LIKELY_DONE", 2)
+    if stale_days >= stale_threshold:
+        return Verdict("STALE", 3)
+    return Verdict("HEALTHY", 0)

--- a/scripts/lifecycle/plan-close-detector.py
+++ b/scripts/lifecycle/plan-close-detector.py
@@ -22,7 +22,11 @@ ACTIVE_DIR = REPO_ROOT / "docs" / "plans" / "active"
 
 # Reuse the frontmatter parser from doc-status-audit.py (DRY — no third parser).
 _audit_path = Path(__file__).resolve().parent / "doc-status-audit.py"
+if not _audit_path.exists():
+    raise ImportError(f"doc-status-audit.py not found: {_audit_path}")
 _spec = importlib.util.spec_from_file_location("doc_status_audit", _audit_path)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Cannot load spec from {_audit_path}")
 _audit = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_audit)
 parse_frontmatter = _audit.parse_frontmatter

--- a/scripts/lifecycle/plan-close-detector.py
+++ b/scripts/lifecycle/plan-close-detector.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""plan-close-detector — detect active plans that are actually complete.
+
+Scans docs/plans/active/*.md, classifies close candidates into confidence
+tiers. Tier1 (allowlisted asserts pass + clean tree / misplaced) is auto-PR
+eligible; Tier2/3 are report-only. Default mode is dry-run (no file moves).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACTIVE_DIR = REPO_ROOT / "docs" / "plans" / "active"
+
+# Reuse the frontmatter parser from doc-status-audit.py (DRY — no third parser).
+_audit_path = Path(__file__).resolve().parent / "doc-status-audit.py"
+_spec = importlib.util.spec_from_file_location("doc_status_audit", _audit_path)
+_audit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_audit)
+parse_frontmatter = _audit.parse_frontmatter
+
+_CHECKBOX_DONE = re.compile(r"^\s*[-*] \[x\]", re.IGNORECASE | re.MULTILINE)
+_CHECKBOX_TODO = re.compile(r"^\s*[-*] \[ \]", re.MULTILINE)
+
+
+@dataclass
+class Signals:
+    path: Path
+    lifecycle: str | None  # frontmatter lifecycle:、無ければ status: で後方互換
+    artifacts: str | None  # 成果物パス列挙 (弱い証拠)
+    asserts: str | None  # allowlist enum キー列挙 (強い証拠)
+    checkboxes_total: int
+    checkboxes_done: int
+
+
+def extract_signals(path: Path) -> Signals:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    fields, _ = parse_frontmatter(text)
+    fields = fields or {}
+    done = len(_CHECKBOX_DONE.findall(text))
+    todo = len(_CHECKBOX_TODO.findall(text))
+    return Signals(
+        path=path,
+        lifecycle=fields.get("lifecycle") or fields.get("status"),
+        artifacts=fields.get("artifacts"),
+        asserts=fields.get("asserts"),
+        checkboxes_total=done + todo,
+        checkboxes_done=done,
+    )

--- a/scripts/lifecycle/plan-close-detector.py
+++ b/scripts/lifecycle/plan-close-detector.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -51,3 +52,60 @@ def extract_signals(path: Path) -> Signals:
         checkboxes_total=done + todo,
         checkboxes_done=done,
     )
+
+
+ASSERTS: dict[str, list[str]] = {
+    "validate-configs": ["task", "validate-configs"],
+    "validate-symlinks": ["task", "validate-symlinks"],
+    "plan-close-tests": [
+        "uv",
+        "run",
+        "pytest",
+        "scripts/tests/test_plan_close_detector.py",
+        "-q",
+    ],
+}
+"""Fixed allowlist mapping an assert key to its argv (run with shell=False).
+
+Plan frontmatter can only reference keys, never arbitrary commands — this is
+the prompt-injection boundary: LLM or external text mixed into a plan cannot
+smuggle a command into the nightly scanner. Keys absent from this map are
+silently ignored, so an unknown or hostile key yields zero valid asserts.
+"""
+
+
+def _csv(field: str) -> list[str]:
+    """Strip outer quotes and split a comma-separated frontmatter field."""
+    v = field.strip().strip('"').strip("'")
+    return [x.strip() for x in v.split(",") if x.strip()]
+
+
+def artifacts_present(artifacts: str) -> bool:
+    """Weak signal: every declared artifact path exists. None or empty is False."""
+    paths = _csv(artifacts)
+    return bool(paths) and all((REPO_ROOT / p).exists() for p in paths)
+
+
+def asserts_satisfied(asserts: str) -> bool:
+    """Strong signal: every allowlisted assert key exits 0 (shell=False).
+
+    Keys not in ASSERTS are ignored; if no valid assert remains, return False
+    (absence of evidence is not evidence of completion).
+    """
+    keys = [k for k in _csv(asserts) if k in ASSERTS]
+    if not keys:
+        return False
+    for k in keys:
+        try:
+            rc = subprocess.run(
+                ASSERTS[k],
+                cwd=REPO_ROOT,
+                timeout=120,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+        except (subprocess.SubprocessError, OSError):
+            return False
+        if rc != 0:
+            return False
+    return True

--- a/scripts/lifecycle/plan-close-detector.py
+++ b/scripts/lifecycle/plan-close-detector.py
@@ -83,10 +83,28 @@ def _csv(field: str) -> list[str]:
     return [x.strip() for x in v.split(",") if x.strip()]
 
 
+def _within_repo(p: str) -> Path | None:
+    """Resolve p under REPO_ROOT, returning None if it escapes the repo.
+
+    artifacts come from plan frontmatter, which the threat model treats as
+    untrusted; a `../` traversal must never let an out-of-repo path count as a
+    present artifact (and, once apply lands, become a move target).
+    """
+    resolved = (REPO_ROOT / p).resolve()
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
 def artifacts_present(artifacts: str) -> bool:
     """Weak signal: every declared artifact path exists. None or empty is False."""
     paths = _csv(artifacts)
-    return bool(paths) and all((REPO_ROOT / p).exists() for p in paths)
+    if not paths:
+        return False
+    resolved = [_within_repo(p) for p in paths]
+    return all(r is not None and r.exists() for r in resolved)
 
 
 def asserts_satisfied(asserts: str) -> bool:
@@ -140,7 +158,7 @@ def classify(
     s = signals
     if s.lifecycle in _CLOSED_LIFECYCLES:
         return Verdict("MISPLACED", 1)
-    if s.lifecycle != "active":
+    if s.lifecycle is not None and s.lifecycle != "active":
         return Verdict("HEALTHY", 0)
     if s.asserts and asserts_satisfied(s.asserts) and tree_clean:
         return Verdict("VERIFIED_DONE", 1)
@@ -298,8 +316,14 @@ def apply_via_pr() -> int:
     of the PR is the final gate. The actual PR creation stays disabled until
     the 30-day calibration milestone proves a Tier1 human-agree rate >= 0.9.
     """
-    if subprocess.run(["git", "diff", "--quiet"], cwd=REPO_ROOT).returncode != 0:
-        raise SystemExit("[plan-close] working tree dirty; abort (preflight)")
+    unstaged = subprocess.run(["git", "diff", "--quiet"], cwd=REPO_ROOT).returncode
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"], cwd=REPO_ROOT
+    ).returncode
+    if unstaged != 0 or staged != 0:
+        raise SystemExit(
+            "[plan-close] working tree dirty (staged or unstaged); abort (preflight)"
+        )
     moves = plan_moves()
     if not moves:
         print("[plan-close] no Tier1 candidates")

--- a/scripts/runtime/nightly/launchd-install.sh
+++ b/scripts/runtime/nightly/launchd-install.sh
@@ -18,6 +18,7 @@ TASKS=(
     "daily-report|23|35|run-daily-report.sh"
     "audit|23|45|run-audit.sh"
     "skill-audit|23|45|run-skill-audit.sh"
+    "plan-close-scan|0|50|run-plan-close-scan.sh"
     # tech-researcher: nightly ゲート相乗り (別ディレクトリ、.. は exec 時に解決)。
     # audit/skill-audit (23:45) の後に置き claude lock 競合を避ける。
     "tech-researcher|23|55|../tech-researcher/run-tech-researcher.sh"

--- a/scripts/runtime/nightly/run-plan-close-scan.sh
+++ b/scripts/runtime/nightly/run-plan-close-scan.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# run-plan-close-scan.sh — docs/plans/active/ を走査し close 候補を Tier 別に検出
+# cron: 50 0 * * *  (DAILY gate)
+# dry-run のみ。auto-apply (--apply-tier1) は calibration milestone まで開放しない。
+# output: docs/plan-close/<date>-close-report.md + candidates.jsonl (pending source of truth)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./lib/nightly-status.sh
+source "${SCRIPT_DIR}/lib/nightly-status.sh"
+
+TASK="plan-close-scan"
+REPO="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# === Cleanup trap (status_end on unexpected exit) ===
+_cleanup() {
+    local ec=$?
+    if [[ -n "${_NIGHTLY_CURRENT_TASK:-}" ]]; then
+        status_end fail "trapped exit_code=$ec"
+    fi
+}
+trap _cleanup EXIT
+
+# === Prereq guards ===
+for cmd in python3 git; do
+    if ! command -v "$cmd" &>/dev/null; then
+        status_begin "$TASK"; status_end fail "preflight: $cmd CLI not found in PATH"
+        exit 0
+    fi
+done
+
+# === Gate ===
+should_run_today "$TASK" DAILY "" 0 || exit 0
+
+status_begin "$TASK"
+
+cd "$REPO"
+OUT=$(python3 scripts/lifecycle/plan-close-detector.py 2>&1) || {
+    status_end fail "detector exit non-zero: ${OUT}"
+    exit 0
+}
+
+# detector の stdout "scanned: N candidates → ..." から件数を抽出 (metric 用)
+COUNT=$(printf '%s' "$OUT" | sed -nE 's/^scanned: ([0-9]+) candidates.*/\1/p')
+COUNT="${COUNT:-0}"
+
+status_end ok "scan complete" "metric.candidates=${COUNT}" \
+    "report=docs/plan-close/${NIGHTLY_DATE}-close-report.md"

--- a/scripts/tests/test_plan_close_detector.py
+++ b/scripts/tests/test_plan_close_detector.py
@@ -135,6 +135,13 @@ def test_classify_healthy_recent():
     assert pcd.classify(s, stale_days=3, tree_clean=True).result == "HEALTHY"
 
 
+def test_git_stale_days_handles_untracked(tmp_path, monkeypatch):
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    f = tmp_path / "x.md"
+    f.write_text("---\nstatus: active\n---\n")
+    assert pcd.git_stale_days(f) >= 0
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/scripts/tests/test_plan_close_detector.py
+++ b/scripts/tests/test_plan_close_detector.py
@@ -142,6 +142,29 @@ def test_git_stale_days_handles_untracked(tmp_path, monkeypatch):
     assert pcd.git_stale_days(f) >= 0
 
 
+def test_artifacts_present_rejects_path_traversal(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "secret.txt").write_text("x")
+    monkeypatch.setattr(pcd, "REPO_ROOT", repo)
+    assert pcd.artifacts_present("../secret.txt") is False
+    (repo / "ok.py").write_text("y")
+    assert pcd.artifacts_present("ok.py") is True
+
+
+def test_classify_none_lifecycle_stale_is_reported():
+    s = pcd.Signals(
+        path=Path("x.md"),
+        lifecycle=None,
+        artifacts=None,
+        asserts=None,
+        checkboxes_total=0,
+        checkboxes_done=0,
+    )
+    assert pcd.classify(s, stale_days=40, tree_clean=True).result == "STALE"
+    assert pcd.classify(s, stale_days=3, tree_clean=True).result == "HEALTHY"
+
+
 def test_plan_moves_misplaced_to_correct_dir(tmp_path, monkeypatch):
     active = tmp_path / "docs/plans/active"
     active.mkdir(parents=True)

--- a/scripts/tests/test_plan_close_detector.py
+++ b/scripts/tests/test_plan_close_detector.py
@@ -1,0 +1,49 @@
+"""plan-close-detector の純ロジック検証。
+
+実行: uv run pytest scripts/tests/test_plan_close_detector.py
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lifecycle"))
+
+pcd = importlib.import_module("plan-close-detector")
+
+
+def _write(tmp_path, name, body):
+    f = tmp_path / name
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def test_extract_signals_reads_lifecycle_artifacts_asserts(tmp_path):
+    body = (
+        "---\n"
+        "lifecycle: active\n"
+        'artifacts: "a.py, b.sh"\n'
+        'asserts: "plan-close-tests"\n'
+        "---\n\n"
+        "- [x] done\n"
+        "- [ ] todo\n"
+    )
+    f = _write(tmp_path, "p.md", body)
+    sig = pcd.extract_signals(f)
+    assert sig.lifecycle == "active"
+    assert sig.artifacts == '"a.py, b.sh"'
+    assert sig.asserts == '"plan-close-tests"'
+    assert sig.checkboxes_total == 2
+    assert sig.checkboxes_done == 1
+
+
+def test_extract_signals_falls_back_to_status(tmp_path):
+    # 既存 plan は status: のみ。lifecycle 欠落時は status を後方互換で読む。
+    f = _write(tmp_path, "old.md", "---\nstatus: completed\n---\n# old\n")
+    assert pcd.extract_signals(f).lifecycle == "completed"
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_plan_close_detector.py
+++ b/scripts/tests/test_plan_close_detector.py
@@ -142,6 +142,18 @@ def test_git_stale_days_handles_untracked(tmp_path, monkeypatch):
     assert pcd.git_stale_days(f) >= 0
 
 
+def test_plan_moves_misplaced_to_correct_dir(tmp_path, monkeypatch):
+    active = tmp_path / "docs/plans/active"
+    active.mkdir(parents=True)
+    (active / "x.md").write_text("---\nlifecycle: deferred\n---\n# x\n")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(pcd, "ACTIVE_DIR", active)
+    moves = pcd.plan_moves()
+    assert any(
+        m["to"].endswith("paused/x.md") and m["result"] == "MISPLACED" for m in moves
+    )
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/scripts/tests/test_plan_close_detector.py
+++ b/scripts/tests/test_plan_close_detector.py
@@ -43,6 +43,31 @@ def test_extract_signals_falls_back_to_status(tmp_path):
     assert pcd.extract_signals(f).lifecycle == "completed"
 
 
+def test_artifacts_present_all_exist(tmp_path, monkeypatch):
+    (tmp_path / "a.py").write_text("x")
+    (tmp_path / "b.sh").write_text("y")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    assert pcd.artifacts_present('"a.py, b.sh"') is True
+
+
+def test_artifacts_present_missing_one(tmp_path, monkeypatch):
+    (tmp_path / "a.py").write_text("x")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    assert pcd.artifacts_present("a.py, b.sh") is False
+
+
+def test_asserts_satisfied_allowlisted(monkeypatch):
+    monkeypatch.setattr(pcd, "ASSERTS", {"ok": ["true"], "ng": ["false"]})
+    assert pcd.asserts_satisfied("ok") is True
+    assert pcd.asserts_satisfied("ok, ng") is False
+
+
+def test_asserts_satisfied_rejects_non_allowlisted(monkeypatch):
+    monkeypatch.setattr(pcd, "ASSERTS", {"ok": ["true"]})
+    assert pcd.asserts_satisfied("rm -rf /") is False
+    assert pcd.asserts_satisfied("! task validate-configs") is False
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/scripts/tests/test_plan_close_detector.py
+++ b/scripts/tests/test_plan_close_detector.py
@@ -68,6 +68,73 @@ def test_asserts_satisfied_rejects_non_allowlisted(monkeypatch):
     assert pcd.asserts_satisfied("! task validate-configs") is False
 
 
+def test_classify_misplaced():
+    s = pcd.Signals(
+        path=Path("docs/plans/active/x.md"),
+        lifecycle="completed",
+        artifacts=None,
+        asserts=None,
+        checkboxes_total=0,
+        checkboxes_done=0,
+    )
+    v = pcd.classify(s, stale_days=5, tree_clean=True)
+    assert v.result == "MISPLACED" and v.tier == 1
+
+
+def test_classify_verified_done_requires_assert_and_clean_tree(monkeypatch):
+    monkeypatch.setattr(pcd, "ASSERTS", {"ok": ["true"]})
+    s = pcd.Signals(
+        path=Path("x.md"),
+        lifecycle="active",
+        artifacts=None,
+        asserts="ok",
+        checkboxes_total=3,
+        checkboxes_done=0,
+    )
+    assert pcd.classify(s, stale_days=1, tree_clean=True).result == "VERIFIED_DONE"
+    assert pcd.classify(s, stale_days=1, tree_clean=False).result == "HEALTHY"
+
+
+def test_classify_artifacts_present_is_tier2(monkeypatch, tmp_path):
+    (tmp_path / "a.py").write_text("x")
+    monkeypatch.setattr(pcd, "REPO_ROOT", tmp_path)
+    s = pcd.Signals(
+        path=Path("x.md"),
+        lifecycle="active",
+        artifacts="a.py",
+        asserts=None,
+        checkboxes_total=3,
+        checkboxes_done=0,
+    )
+    v = pcd.classify(s, stale_days=1, tree_clean=True)
+    assert v.result == "ARTIFACTS_PRESENT" and v.tier == 2
+
+
+def test_classify_likely_done_is_tier2():
+    s = pcd.Signals(
+        path=Path("x.md"),
+        lifecycle="active",
+        artifacts=None,
+        asserts=None,
+        checkboxes_total=4,
+        checkboxes_done=4,
+    )
+    v = pcd.classify(s, stale_days=40, tree_clean=True)
+    assert v.result == "LIKELY_DONE" and v.tier == 2
+
+
+def test_classify_healthy_recent():
+    s = pcd.Signals(
+        path=Path("x.md"),
+        lifecycle="active",
+        artifacts=None,
+        asserts=None,
+        checkboxes_total=4,
+        checkboxes_done=1,
+    )
+    assert pcd.classify(s, stale_days=3, tree_clean=True).result == "HEALTHY"
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## 概要

`status: active` のまま放置され「死蔵」と誤判定される完了済み plan を機械検出する nightly 検出器 `plan-close-detector.py` を新設。完了シグナルを確信度 **Tier** に分類し、Tier1 のみ自動 PR 提案の対象にする（直接 move/commit はしない）。

きっかけ: 直近の棚卸しで nix-migration plan が「checkbox 0 のまま実装完了・稼働中」だったのに `status` 放置で死蔵に見えた問題。「status frontmatter を閉じる機械ゲートの欠落」を恒久 artifact 化。

プラン: `docs/plans/active/2026-06-06-plan-status-close-gate-plan.md`（Codex Spec/Plan Gate: REVISE 反映済み）

## Tier 分類

| 結果 | 条件 | Tier | 自動 PR |
|---|---|---|---|
| `MISPLACED` | lifecycle ∈ {completed,archive,deferred,done,paused} かつ active/ に存在 | 1 | ○ |
| `VERIFIED_DONE` | lifecycle=active かつ **allowlisted assert 成功** かつ **tree clean** | 1 | ○ |
| `ARTIFACTS_PRESENT` | 成果物パス存在のみ（弱証拠） | 2 | × |
| `LIKELY_DONE` | stale + checkbox 全 done | 2 | × |
| `STALE` | stale のみ | 3 | × |

**設計の肝**: 「存在 ≠ 完了」。パス存在のみは Tier2 に降格し、Tier1（自動 PR）は allowlisted assert の exit 0 + clean tree を要求して途中実装の誤クローズを構造的に防ぐ。

## セキュリティ境界（prompt injection 遮断）

`asserts:` frontmatter は detector 内の固定 `ASSERTS` allowlist のキーのみ参照可。任意コマンドは `shell=False` で実行不可、allowlist 外キーは無視。`artifacts:` パスは `_within_repo()` で REPO_ROOT 内に限定（`../` traversal 拒否）。

## 安全機構（auto-apply）

`--apply-tier1` は **30 日 calibration（human-agree 率 ≥ 0.9）まで gated**。`apply_via_pr()` は preflight（global tree clean、staged/unstaged 両方）後に SystemExit する stub で、現状 move/commit は一切しない（人間 merge が最後の砦）。

## 変更ファイル

- **新規** `scripts/lifecycle/plan-close-detector.py` — 検出器本体
- **新規** `scripts/tests/test_plan_close_detector.py` — 15 テスト（TDD）
- **新規** `scripts/runtime/nightly/run-plan-close-scan.sh` — nightly runner（`nightly-status.sh` lib 統合）
- **変更** `scripts/runtime/nightly/launchd-install.sh` — TASKS に `plan-close-scan|0|50` 追加
- **変更** `PLANS.md` / `.config/claude/references/doc-status-schema.md` — `lifecycle/artifacts/asserts` 規約化 + `status` 語彙分離

## dogfood 結果

実 `docs/plans/active/` を走査し、誤配置 `2026-05-23-skill-guide-absorb-plan.md`(lifecycle=completed) を MISPLACED Tier1、本物の stale plan 2件を Tier3 で正しく検出。

## レビュー

Codex Review Gate（codex-reviewer + code-reviewer 並列）通過。code-reviewer の MUST 2件（path traversal / preflight staged）+ 実バグ 1件（lifecycle=None の stale 未検出）を修正済み。最終: 両者 **PASS**。

## ⚠️ merge 後の必須手順

launchd 実インストールは **merge 後に main から**実行してください（worktree から走らせると plist が transient パスを指すため未実施）:

```bash
bash scripts/runtime/nightly/launchd-install.sh
launchctl list | grep plan-close-scan
```

## テスト

```
uv run pytest scripts/tests/test_plan_close_detector.py -q  # 15 passed
uv run ruff check scripts/lifecycle/plan-close-detector.py  # clean
```
