### PR TITLE
✨ feat(setup): provision Claude plugins from settings.json via task claude:plugins

### DIFF
--- a/.bin/init-install.sh
+++ b/.bin/init-install.sh
@@ -228,35 +228,19 @@ setup_claude_plugins() {
     return
   fi
 
-  # Marketplaces
-  local marketplaces=(
-    "anthropics/claude-code"
-    "anthropics/claude-plugins-official"
-    "obra/superpowers-marketplace"
-  )
-
-  for mp in "${marketplaces[@]}"; do
-    log "Adding marketplace: $mp"
-    if ! claude plugin marketplace add "$mp" >> "$LOG_FILE" 2>&1; then
-      log "Marketplace $mp already exists (continuing)"
+  # Single source of truth: settings.json (enabledPlugins + extraKnownMarketplaces).
+  # The sync script adds marketplaces and installs every enabled plugin, so the
+  # list does not drift from what Claude actually has enabled. (Was a hardcoded
+  # marketplace/plugin list here — removed to avoid drift.)
+  local sync_script="$DOTFILES_DIR/scripts/lifecycle/claude-plugins-sync.sh"
+  if [ -x "$sync_script" ]; then
+    log "Installing Claude Code plugins from settings.json..."
+    if ! "$sync_script" install >> "$LOG_FILE" 2>&1; then
+      warn "Plugin sync reported problems (see $LOG_FILE)"
     fi
-  done
-
-  # Plugins
-  local plugins=(
-    "superpowers@superpowers-marketplace"
-    "frontend-design@claude-code-plugins"
-    "code-simplifier@claude-plugins-official"
-    "playground@claude-plugins-official"
-    "pr-review-toolkit@claude-code-plugins"
-  )
-
-  for plugin in "${plugins[@]}"; do
-    log "Installing plugin: $plugin"
-    if ! claude plugin install "$plugin" >> "$LOG_FILE" 2>&1; then
-      warn "Failed to install plugin: $plugin"
-    fi
-  done
+  else
+    warn "plugin sync script not found at $sync_script — skipping plugin install"
+  fi
 
   log "Claude Code plugin setup complete"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,13 +58,16 @@ tasks:
       Post-clone / post-nix:switch orchestration. Idempotent — safe to re-run.
       Pre-req: `task nix:bootstrap PROFILE=...` (first machine) or `task nix:switch PROFILE=...`.
       Chains the steps that are NOT covered by nix-darwin / init-install.sh:
-        build-hooks → lefthook:install → build-claude → patch-claude → doctor
+        build-hooks → lefthook:install → build-claude → patch-claude → claude:plugins → doctor
+      Skills are vendored in the repo (symlinked by nix), so nix:switch already
+      provides them; claude:plugins fetches the plugin payloads that are machine-local.
       Excluded (run manually if needed): cmux:link, cmux:worktree-daemon:install.
     cmds:
       - task: build-hooks
       - task: lefthook:install
       - task: build-claude
       - task: patch-claude
+      - task: claude:plugins
       - task: doctor
 
   brew:
@@ -212,6 +215,11 @@ tasks:
     cmds:
       - bash scripts/lifecycle/doctor.sh brew
 
+  doctor:plugins:
+    desc: Check Claude Code plugins declared in settings.json vs installed (delegates to claude:plugins:check)
+    cmds:
+      - task: claude:plugins:check
+
   doctor:stale:
     desc: Inventory stale state (orphaned codex job state, backup residue) — read-only, deletes nothing
     cmds:
@@ -260,6 +268,20 @@ tasks:
     desc: Check if CLAUDE.md matches templates (no write)
     cmds:
       - bash ~/.claude/scripts/lifecycle/build-claude.sh --check
+
+  claude:plugins:
+    desc: |
+      Install Claude Code marketplaces + plugins declared in settings.json
+      (enabledPlugins + extraKnownMarketplaces). Idempotent. Run on a fresh
+      clone so user-scope plugins present on other machines are materialized.
+      Skills are vendored in the repo (nix symlink) and need no install step.
+    cmds:
+      - bash ~/dotfiles/scripts/lifecycle/claude-plugins-sync.sh install
+
+  claude:plugins:check:
+    desc: 'Read-only: report plugins declared in settings.json but not installed (exit 1 if any missing)'
+    cmds:
+      - bash ~/dotfiles/scripts/lifecycle/claude-plugins-sync.sh check
 
   codex-janitor:
     desc: Run the repo-local Codex janitor workflow runner

--- a/scripts/lifecycle/claude-plugins-sync.sh
+++ b/scripts/lifecycle/claude-plugins-sync.sh
@@ -37,6 +37,14 @@ SETTINGS="${CLAUDE_SETTINGS:-$HOME/.claude/settings.json}"
 INSTALLED="${CLAUDE_INSTALLED_PLUGINS:-$HOME/.claude/plugins/installed_plugins.json}"
 MODE="${1:-install}"
 
+# Requires bash 4.0+ (declare -A, mapfile). macOS ships /bin/bash 3.2, which
+# would die on `declare -A` with a cryptic "invalid option". Fail fast with a
+# legible message — the nix-managed bash is expected to be ahead in PATH.
+if ((BASH_VERSINFO[0] < 4)); then
+  echo "[plugins] ERROR: requires bash 4.0+ (found $BASH_VERSION). Install a modern bash via nix/brew and ensure it precedes /bin/bash in PATH." >&2
+  exit 2
+fi
+
 # Built-in marketplaces not declared in extraKnownMarketplaces.
 # name → github repo passed to `claude plugin marketplace add`.
 declare -A DEFAULT_MARKETPLACES=(
@@ -134,12 +142,12 @@ for entry in "${ENABLED[@]}"; do
   mp="${entry##*@}"
   [ -n "${seen_mp[$mp]:-}" ] && continue
   seen_mp["$mp"]=1
-  if ! source=$(resolve_marketplace "$mp"); then
+  if ! mp_source=$(resolve_marketplace "$mp"); then
     warn "marketplace '$mp' unresolvable — plugins from it will be skipped"
     continue
   fi
-  log "marketplace add: $mp ($source)"
-  if ! claude plugin marketplace add "$source" >/dev/null 2>&1; then
+  log "marketplace add: $mp ($mp_source)"
+  if ! claude plugin marketplace add "$mp_source" >/dev/null 2>&1; then
     log "  marketplace '$mp' already present (continuing)"
   fi
 done

--- a/scripts/lifecycle/claude-plugins-sync.sh
+++ b/scripts/lifecycle/claude-plugins-sync.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# scripts/lifecycle/claude-plugins-sync.sh
+#
+# Materialize the declarative Claude Code plugin/marketplace config from
+# settings.json onto this machine. settings.json (`enabledPlugins` +
+# `extraKnownMarketplaces`) is the single source of truth — this script only
+# runs `claude plugin marketplace add` + `claude plugin install` to fetch the
+# payloads that a fresh machine is missing. Idempotent: safe to re-run.
+#
+# Why this exists: skills are vendored into the repo (.config/claude/skills/,
+# symlinked by nix), so they arrive with the clone. Plugins are NOT — their
+# payloads live in ~/.claude/plugins/cache/ which is machine-local. Without
+# this step a team member's clone enables plugins in settings.json that have
+# no payload installed. See Taskfile `setup` / `claude:plugins`.
+#
+# Usage:
+#   claude-plugins-sync.sh install   # add marketplaces + install enabled plugins (default)
+#   claude-plugins-sync.sh check     # read-only: report declared-but-missing plugins (exit 1 if any)
+#
+# Source of truth: $CLAUDE_SETTINGS (default ~/.claude/settings.json)
+#   - extraKnownMarketplaces.<name>.source → github repo | directory path
+#   - enabledPlugins."<name>@<marketplace>" = true
+#
+# Built-in marketplaces (claude-plugins-official, claude-code-plugins) are not
+# listed in extraKnownMarketplaces; they map to anthropics repos via the
+# DEFAULT_MARKETPLACES table below. Plugins whose marketplace cannot be
+# resolved (e.g. a stale entry pointing at an undefined marketplace) are
+# warned and skipped — never fatal.
+#
+# Exit codes:
+#   install: 0 always unless a hard dependency (jq) is missing → 2
+#   check:   0 if nothing missing, 1 if declared plugins are not installed, 2 on dep error
+set -uo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETTINGS="${CLAUDE_SETTINGS:-$HOME/.claude/settings.json}"
+INSTALLED="${CLAUDE_INSTALLED_PLUGINS:-$HOME/.claude/plugins/installed_plugins.json}"
+MODE="${1:-install}"
+
+# Built-in marketplaces not declared in extraKnownMarketplaces.
+# name → github repo passed to `claude plugin marketplace add`.
+declare -A DEFAULT_MARKETPLACES=(
+  ["claude-plugins-official"]="anthropics/claude-plugins-official"
+  ["claude-code-plugins"]="anthropics/claude-code"
+)
+
+c_green=$'\033[0;32m'; c_yellow=$'\033[1;33m'; c_red=$'\033[0;31m'; c_reset=$'\033[0m'
+log()  { echo "${c_green}[plugins]${c_reset} $*"; }
+warn() { echo "${c_yellow}[plugins] WARN:${c_reset} $*" >&2; }
+err()  { echo "${c_red}[plugins] ERROR:${c_reset} $*" >&2; }
+
+command -v jq >/dev/null 2>&1 || { err "jq required"; exit 2; }
+if [ ! -f "$SETTINGS" ]; then
+  err "settings.json not found: $SETTINGS"
+  exit 2
+fi
+
+# Resolve a marketplace name to the <source> argument for `marketplace add`.
+# Prints the source on success; prints nothing and returns 1 if unresolvable.
+resolve_marketplace() {
+  local name="$1" kind path repo
+  kind=$(jq -r --arg n "$name" '.extraKnownMarketplaces[$n].source.source // empty' "$SETTINGS")
+  case "$kind" in
+    github)
+      jq -r --arg n "$name" '.extraKnownMarketplaces[$n].source.repo' "$SETTINGS"
+      return 0
+      ;;
+    directory)
+      # The recorded path is absolute to the original machine. Rebase onto this
+      # repo: directory marketplaces are vendored under .config/claude/marketplaces/.
+      path="$DOTFILES_DIR/.config/claude/marketplaces/$name"
+      if [ -d "$path" ]; then echo "$path"; return 0; fi
+      return 1
+      ;;
+    "")
+      repo="${DEFAULT_MARKETPLACES[$name]:-}"
+      if [ -n "$repo" ]; then echo "$repo"; return 0; fi
+      return 1
+      ;;
+  esac
+  return 1
+}
+
+# Enabled plugins ("name@marketplace") where value is true.
+mapfile -t ENABLED < <(
+  jq -r '.enabledPlugins // {} | to_entries[] | select(.value == true) | .key' "$SETTINGS"
+)
+
+if [ "${#ENABLED[@]}" -eq 0 ]; then
+  warn "no enabled plugins declared in $SETTINGS — nothing to do"
+  exit 0
+fi
+
+# ----------------------------------------------------------------------------
+# check mode: read-only diff of declared vs installed (by base plugin name, so
+# a marketplace rename does not produce a false "missing").
+# ----------------------------------------------------------------------------
+if [ "$MODE" = "check" ]; then
+  declare -A installed_base=()
+  if [ -f "$INSTALLED" ]; then
+    while IFS= read -r key; do
+      installed_base["${key%@*}"]=1
+    done < <(jq -r '.plugins // {} | keys[]' "$INSTALLED")
+  fi
+  missing=0
+  for entry in "${ENABLED[@]}"; do
+    base="${entry%@*}"; mp="${entry##*@}"
+    if [ -n "${installed_base[$base]:-}" ]; then
+      echo "ok      $entry"
+    elif ! resolve_marketplace "$mp" >/dev/null; then
+      echo "skip    $entry (marketplace '$mp' unresolvable — stale entry)"
+    else
+      echo "MISSING $entry"
+      missing=$((missing + 1))
+    fi
+  done
+  echo ""
+  echo "[summary] declared=${#ENABLED[@]}, missing=$missing"
+  [ "$missing" -eq 0 ]
+  exit $?
+fi
+
+# ----------------------------------------------------------------------------
+# install mode
+# ----------------------------------------------------------------------------
+if ! command -v claude >/dev/null 2>&1; then
+  warn "Claude Code CLI not installed — skipping plugin install"
+  exit 0
+fi
+
+# 1. Add every marketplace referenced by an enabled plugin (dedup, resolvable only).
+declare -A seen_mp=()
+for entry in "${ENABLED[@]}"; do
+  mp="${entry##*@}"
+  [ -n "${seen_mp[$mp]:-}" ] && continue
+  seen_mp["$mp"]=1
+  if ! source=$(resolve_marketplace "$mp"); then
+    warn "marketplace '$mp' unresolvable — plugins from it will be skipped"
+    continue
+  fi
+  log "marketplace add: $mp ($source)"
+  if ! claude plugin marketplace add "$source" >/dev/null 2>&1; then
+    log "  marketplace '$mp' already present (continuing)"
+  fi
+done
+
+# 2. Install each enabled plugin (user scope is the CLI default).
+installed_ok=0; skipped=0; failed=0
+for entry in "${ENABLED[@]}"; do
+  mp="${entry##*@}"
+  if ! resolve_marketplace "$mp" >/dev/null; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  log "install: $entry"
+  if claude plugin install "$entry" --scope user >/dev/null 2>&1; then
+    installed_ok=$((installed_ok + 1))
+  else
+    warn "  failed to install $entry (already installed? see: claude plugin list)"
+    failed=$((failed + 1))
+  fi
+done
+
+echo ""
+log "done — installed/ok=$installed_ok, skipped(unresolvable)=$skipped, failed=$failed"
+exit 0


### PR DESCRIPTION
## Summary
- `task claude:plugins` / `claude:plugins:check` / `doctor:plugins` を追加。`settings.json`（`enabledPlugins` + `extraKnownMarketplaces`）を唯一の source of truth として、team/別PC で marketplace + plugin を冪等にインストールできるようにした
- `task setup` のチェーンに `claude:plugins` を組込（build-claude→patch-claude→claude:plugins→doctor）。fresh clone が 1 コマンドで揃う
- `.bin/init-install.sh` のドリフトしたハードコード（marketplace 3 / plugin 5、実態は 8 / 16）を撤去し新スクリプト呼び出しに統一（DRY）

## 背景 / なぜ
- プラグイン install は宣言（settings.json）だけ存在し、`task setup` が一切実行していなかった。実行していたのは legacy `init-install.sh` のみでハードコードが激しくドリフト
- 名前空間付き skill（`superpowers:*`, `mattpocock-skills:*`, `obsidian:*`, `codex:*` 等）は**プラグイン提供**のため、プラグイン未install だと skill ごと消える＝「別PCで skill が無い」の主因
- `~/.claude/skills/` の 121 skill は repo vendored + nix symlink で `nix:switch` 時に揃うため、追加の install 不要

## 設計判断
- settings.json 駆動（新 manifest を作らず単一 source of truth、ドリフト二重化を回避）
- 解決不能 marketplace は warn+skip 吸収（`datadog@kw-marketplace` 死蔵 / terraform 名不一致）。settings.json は本 PR では不変
- directory marketplace（mattpocock-skills）は絶対パスを `\$DOTFILES_DIR/.config/claude/marketplaces/<name>` に rebase

## 既知の残ドリフト（別途）
- `terraform-skill@antonbabenko-terraform`: repo の marketplace.json は自身を `antonbabenko` と宣言するが settings.json は別名参照 → fresh PC で install 失敗（現状 disabled で影響軽微）。修正は settings.json 2 箇所統一

## Test plan
- [x] `task claude:plugins:check` → declared=16, missing=0（現PC）
- [x] `claude-plugins-sync.sh install` 冪等実行 → 14 ok / 1 skip(datadog) / 1 fail(terraform drift)
- [x] `task validate-configs` 通過、`bash -n` 構文OK、Taskfile 配線確認
- [ ] fresh/別PC で `task setup` 後にプラグイン+名前空間skillが揃うことを実機確認