### PR TITLE
✨ feat(nix): add zed editor as homebrew cask

### DIFF
--- a/nix/darwin/default.nix
+++ b/nix/darwin/default.nix
@@ -72,6 +72,7 @@
       "macskk"
       "jordanbaird-ice"
       "raycast"
+      "zed"                   # provides `zed` CLI via binary stanza
     ];
   };
 }


### PR DESCRIPTION
## 背景

`zed` コマンド（Zed エディタ）を使えるようにしたい。Zed は GUI アプリなので、既存の dotfiles 方針に従い nix-darwin の `homebrew.casks` で宣言的に管理する。

## 変更

`nix/darwin/default.nix` の `homebrew.casks` に `zed` を1行追加。

- `wezterm` / `ghostty` / `raycast` 等と同じ「GUI アプリ = cask」パターンに準拠
- homebrew の `zed` cask は `binary` stanza で `Zed.app/Contents/MacOS/cli` を `zed` として PATH に貼るため、別途 CLI セットアップ不要で `zed .` が使える

## 検討

- **採用**: homebrew cask
- **却下**: `pkgs.zed-editor`（home.packages 経由）— nixpkgs の darwin GUI ビルドは重く壊れやすく、既存の GUI=cask 統一方針を崩すため

Brewfile は fonts のみで casks の source of truth ではない（既に nix 側に集約済み）ため、Brewfile 変更は不要。

## 反映手順（マージ後）

```bash
darwin-rebuild switch --flake ~/dotfiles/nix#private
```

## 検証状況

- ⚠️ **未 rebuild**: 設定追加のみ。実際の `darwin-rebuild switch` による反映・`zed` コマンド動作確認は未実施。マージ後に手動反映が必要。