### PR TITLE
✨ feat(nightly): wake Mac for nightly batch then auto-sleep (夜勤マシン化)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -328,3 +328,23 @@ tasks:
       - launchctl bootout gui/$UID/com.cmux.worktree-daemon 2>/dev/null || true
       - rm -f $HOME/Library/LaunchAgents/com.cmux.worktree-daemon.plist
       - echo "✅ cmux-worktree-daemon uninstalled"
+
+  nightly:install:
+    desc: 'Install/reload all nightly LaunchAgents incl. caffeinate umbrella (夜勤マシン化)'
+    cmds:
+      - bash {{.TASKFILE_DIR}}/scripts/runtime/nightly/launchd-install.sh
+
+  nightly:wake:
+    desc: 'Apply scheduled wake for nightly batch via pmset (requires sudo + AC power)'
+    cmds:
+      - bash {{.TASKFILE_DIR}}/scripts/runtime/nightly/setup-nightly-wake.sh apply
+
+  nightly:wake:cancel:
+    desc: 'Cancel scheduled wake (pmset repeat cancel, requires sudo)'
+    cmds:
+      - bash {{.TASKFILE_DIR}}/scripts/runtime/nightly/setup-nightly-wake.sh cancel
+
+  nightly:wake:status:
+    desc: 'Show scheduled power events (pmset -g sched)'
+    cmds:
+      - bash {{.TASKFILE_DIR}}/scripts/runtime/nightly/setup-nightly-wake.sh status

--- a/scripts/runtime/nightly/launchd-install.sh
+++ b/scripts/runtime/nightly/launchd-install.sh
@@ -10,7 +10,17 @@ mkdir -p "$AGENTS_DIR"
 
 VAULT_PATH="${OBSIDIAN_VAULT_PATH:-$HOME/Documents/Obsidian Vault}"
 
+# wake/caffeinate 時刻の単一真実源 (setup-nightly-wake.sh の pmset と揃える)
+# shellcheck source=./nightly-wake.env
+source "${NIGHTLY_DIR}/nightly-wake.env"
+
+[[ "${NIGHTLY_WAKE_HOUR:-}" =~ ^[0-9]+$ && "${NIGHTLY_WAKE_MINUTE:-}" =~ ^[0-9]+$ ]] \
+    || { echo "[ERROR] nightly-wake.env: NIGHTLY_WAKE_HOUR/MINUTE must be integers" >&2; exit 1; }
+
 TASKS=(
+    # caffeinate アンブレラ: wake 時刻に発火し、バッチ完了までスリープを抑止する
+    # (pmset の `sleep 1` 対策)。最初の実ジョブ dep-audit (22:30) より前に置く。
+    "caffeinate|${NIGHTLY_WAKE_HOUR}|${NIGHTLY_WAKE_MINUTE}|nightly-caffeinate.sh"
     "dep-audit|22|30|run-dep-audit.sh"
     "golden-check|23|15|run-golden-check.sh"
     "friction-aggregate|23|20|run-friction-aggregate.sh"

--- a/scripts/runtime/nightly/launchd-uninstall.sh
+++ b/scripts/runtime/nightly/launchd-uninstall.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# launchd-uninstall.sh — 7 nightly LaunchAgent を unload + 削除
+# launchd-uninstall.sh — nightly LaunchAgent を unload + 削除
 set -euo pipefail
 AGENTS_DIR="$HOME/Library/LaunchAgents"
-TASKS=(dep-audit golden-check friction-aggregate health-check daily-report audit skill-audit)
+TASKS=(caffeinate dep-audit golden-check friction-aggregate health-check daily-report audit skill-audit plan-close-scan tech-researcher)
 for task in "${TASKS[@]}"; do
     plist="$AGENTS_DIR/com.user.nightly.${task}.plist"
     [[ -f "$plist" ]] || { echo "[skip] $plist not found"; continue; }

--- a/scripts/runtime/nightly/nightly-caffeinate.sh
+++ b/scripts/runtime/nightly/nightly-caffeinate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# nightly-caffeinate.sh — 夜間バッチ枠の覚醒維持アンブレラ。
+#
+# pmset scheduled wake (setup-nightly-wake.sh) で起きた Mac を、バッチ完了まで
+# 眠らせない。pmset の `sleep 1` (1分アイドルで即スリープ) のままだと、起床直後に
+# 再スリープして staggered ジョブ群が走らないため、覚醒維持の assertion を張る。
+#
+# launchd com.user.nightly.caffeinate が wake 時刻に発火しこれを起動する。
+# 注意: caffeinate 単独ではスリープ中の Mac を起こせない。起床は pmset が担う (役割分担)。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./nightly-wake.env
+source "${SCRIPT_DIR}/nightly-wake.env"
+
+SECS="${NIGHTLY_CAFFEINATE_SECONDS:-10800}"
+[[ "$SECS" =~ ^[0-9]+$ ]] && (( SECS > 0 )) \
+    || { echo "[nightly-caffeinate] FATAL: NIGHTLY_CAFFEINATE_SECONDS must be a positive integer (got: '$SECS')" >&2; exit 1; }
+
+echo "[nightly-caffeinate] hold awake for ${SECS}s at $(date '+%Y-%m-%dT%H:%M:%S%z')"
+# -i: idle sleep 抑止 / -s: system sleep 抑止 (AC 接続時のみ有効) / -t: 指定秒で自動失効
+exec caffeinate -i -s -t "$SECS"

--- a/scripts/runtime/nightly/nightly-wake.env
+++ b/scripts/runtime/nightly/nightly-wake.env
@@ -1,0 +1,17 @@
+# nightly-wake.env — 夜間バッチの wake / caffeinate 時刻の単一真実源 (git 管理)
+#
+# setup-nightly-wake.sh (pmset scheduled wake) と launchd-install.sh (caffeinate plist)
+# の双方が source する。ここを変更したら `task nightly:wake` と `task nightly:install`
+# を再実行して反映する。
+#
+# 背景: macOS の pmset は宣言的設定ファイルを持たない (システム電源状態に直接書く) ため、
+# 「時刻は git 管理した env、適用はスクリプト + Taskfile」で再現可能にしている。
+
+# 夜間バッチ枠の起床時刻。最初のジョブ dep-audit (22:30) より前に置く。
+NIGHTLY_WAKE_HOUR=22
+NIGHTLY_WAKE_MINUTE=15
+
+# caffeinate で覚醒維持する秒数。pmset で起きた Mac を、最後のジョブ
+# plan-close-scan (00:50) + 余裕までスリープさせない (pmset の `sleep 1` 対策)。
+# 10800s = 3h → wake(22:15) から 01:15 まで。失効後は pmset の sleep 設定で自然スリープ。
+NIGHTLY_CAFFEINATE_SECONDS=10800

--- a/scripts/runtime/nightly/setup-nightly-wake.sh
+++ b/scripts/runtime/nightly/setup-nightly-wake.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# setup-nightly-wake.sh — 夜間バッチ枠の scheduled wake を冪等適用 (pmset)。
+#
+# macOS の pmset は宣言的設定ファイルを持たないため、git 管理した nightly-wake.env の
+# 時刻をこのスクリプトで適用する。別 PC 再現は `task nightly:wake`。
+#
+# 前提 (正直に): ノート (MacBook) では AC 接続時のみ scheduled wake が確実に有効。
+# バッテリー駆動時は womp 抑制で起床しないことがある。夜は電源接続 + 蓋を閉じない
+# (または外部ディスプレイ) こと。これは OS/ハード制約でコード回避不能。
+#
+# pmset repeat は wake の繰り返しスケジュールを 1 枠だけ持つ。apply は既存 repeat を
+# 上書きする (冪等)。cancel は全 repeat イベントを解除する点に注意。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./nightly-wake.env
+source "${SCRIPT_DIR}/nightly-wake.env"
+
+[[ "${NIGHTLY_WAKE_HOUR:-}" =~ ^[0-9]+$ ]] && (( NIGHTLY_WAKE_HOUR <= 23 )) \
+    || { echo "[FATAL] NIGHTLY_WAKE_HOUR must be an integer 0-23 (got: '${NIGHTLY_WAKE_HOUR:-}')" >&2; exit 1; }
+[[ "${NIGHTLY_WAKE_MINUTE:-}" =~ ^[0-9]+$ ]] && (( NIGHTLY_WAKE_MINUTE <= 59 )) \
+    || { echo "[FATAL] NIGHTLY_WAKE_MINUTE must be an integer 0-59 (got: '${NIGHTLY_WAKE_MINUTE:-}')" >&2; exit 1; }
+
+HH=$(printf '%02d' "$NIGHTLY_WAKE_HOUR")
+MM=$(printf '%02d' "$NIGHTLY_WAKE_MINUTE")
+CMD="${1:-apply}"
+
+case "$CMD" in
+    apply)
+        echo "[nightly-wake] applying: pmset repeat wakeorpoweron MTWRFSU ${HH}:${MM}:00 (要 sudo)"
+        sudo pmset repeat wakeorpoweron MTWRFSU "${HH}:${MM}:00"
+        echo "[nightly-wake] done. current schedule:"
+        pmset -g sched
+        ;;
+    cancel)
+        echo "[nightly-wake] cancelling all repeating power events: pmset repeat cancel (要 sudo)"
+        sudo pmset repeat cancel
+        ;;
+    status)
+        pmset -g sched
+        ;;
+    *)
+        echo "usage: $0 {apply|cancel|status}" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## 背景

放置すると MacBook がスリープし、夜間 launchd バッチ群（22:30〜00:50: dep-audit / golden-check / health-check / daily-report / audit / skill-audit / plan-close-scan / tech-researcher）が定刻発火しない。寝起きで遅延キャッチアップ実行され、複数ジョブが claude lock を奪い合って連鎖 fail していた（6/8 夜: audit/daily-report が lock timeout 2492s、6/9 tech-researcher が通常60-100s→46分）。

## 変更

「不在時間だけ計画的に起こして働かせる」夜勤マシン化。既存の7+1ジョブ定義は変更せず最小追加。

- **`nightly-wake.env`** — wake 時刻・caffeinate 秒数の単一真実源（git 管理）。pmset と launchd plist が双方 source し時刻ズレを構造的に排除
- **`nightly-caffeinate.sh`** — 覚醒維持アンブレラ（`caffeinate -i -s -t 10800` = 22:15→01:15）。pmset の `sleep 1`（1分アイドルで即スリープ）対策
- **`setup-nightly-wake.sh`** — `pmset repeat wakeorpoweron` を冪等適用（apply/cancel/status）
- **`launchd-install.sh` / `launchd-uninstall.sh`** — caffeinate タスク追加。uninstall の既存欠落（plan-close-scan / tech-researcher）も追補
- **`Taskfile.yml`** — `nightly:install` / `nightly:wake` / `:cancel` / `:status`

役割分担: **pmset がスリープ中の Mac を起こし**、**caffeinate が起きた Mac をバッチ完了まで眠らせ**、失効後は自然スリープ。

## 有効化

```
task nightly:install   # sudo 不要・冪等
task nightly:wake      # 要 sudo（pmset）
```

## 前提・制約

- **AC 接続 + 蓋を閉じない（or 外部ディスプレイ）が必須**（ノートの scheduled wake は OS/ハード制約で AC 時のみ有効、`womp 0` on battery）
- **race（未検証）**: wake と caffeinate が同分発火。起床〜assertion の数秒窓で `sleep 1` 再スリープの理論的可能性。既存システムで「wake 後 launchd 発火」は実証済み（6/9 が 00:03 起動）のため低リスクだが、**初回夜間ログで dep-audit(22:30) 発火を要確認**

## レビュー（5体並列, PASS after fix）

- ✅ 採用: env 値の整数/範囲バリデーション（手編集の境界で Fail Fast。typo の `00:00:00` wake / `caffeinate -t 0`=無保護 をサイレント回避）。uninstall array 完成
- ❌ 却下 false positive: caffeinate 二重起動（21h 間隔で重複せず）/ `$0` 破損（既存稼働スクリプトで実証済）/ XML injection（git 管理の単一ユーザー設定で過剰）

## 検証

bash 構文 / plist valid XML / バリデーション発火（HOUR=99・SECS=0→FATAL）/ caffeinate フラグ動作。実システムへの load は未実施（コミット後に install で有効化）。