### PR TITLE
🐛 fix(build-claude): worktree 対応 — build-claude-check の誤 block 解消

### DIFF
--- a/.config/claude/scripts/lifecycle/build-claude.sh
+++ b/.config/claude/scripts/lifecycle/build-claude.sh
@@ -4,8 +4,9 @@
 #   --check: 差分確認のみ（書き込みしない）
 set -euo pipefail
 
-TEMPLATE_DIR="${HOME}/dotfiles/.config/claude/templates/claude-md"
-OUTPUT="${HOME}/dotfiles/.config/claude/CLAUDE.md"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "${HOME}/dotfiles")"
+TEMPLATE_DIR="${REPO_ROOT}/.config/claude/templates/claude-md"
+OUTPUT="${REPO_ROOT}/.config/claude/CLAUDE.md"
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 


### PR DESCRIPTION
## Summary
- worktree からの**全 commit** が `build-claude-check` (pre-commit) で誤 block される問題を修正
- `build-claude.sh` の OUTPUT/TEMPLATE パスを `${HOME}/dotfiles` ハードコードから `git rev-parse --show-toplevel` ベースに変更

## 真因
`9ed941b` で導入された `build-claude.sh` は `${HOME}/dotfiles/.config/claude/CLAUDE.md` を固定参照していたため、worktree から commit すると **メインツリー（`docs/wiring-check-2-rust-drift-plan` 等の古いブランチ・テンプレート不整合）の CLAUDE.md** を比較対象にしていた。master 上の CLAUDE.md はテンプレートと一致しているにもかかわらず、全 worktree commit が block されていた（CLAUDE.md 本体の再生成漏れではなかった）。

## 修正
`REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "${HOME}/dotfiles")"` で実行コンテキストの repo root を参照。worktree では worktree の、メインでは メインの CLAUDE.md/templates を見る。

## Test plan
- [x] worktree で `build-claude.sh --check` → "up to date (no changes)"
- [x] 本 commit 自体が build-claude-check を通過（worktree で commit 成功）
- [x] Foundation 内容は保持（CLAUDE.md = templates 結合、no changes）
- [x] `bash -n` 構文チェック pass