### PR TITLE
✨ feat(nightly): learned-promote 配線 + fail リトライ + kill-switch (自己改善ループ完結 PR-1)

### DIFF
--- a/.config/claude/scripts/learner/calibration-verdict-logger.py
+++ b/.config/claude/scripts/learner/calibration-verdict-logger.py
@@ -41,6 +41,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from storage import get_data_dir, read_jsonl
 
 CLASSES = ("mechanical", "advisory", "reject", "defer")
+PROMOTE_CLASSES = ("adopted", "rejected")
+ALL_CLASSES = CLASSES + PROMOTE_CLASSES
+SOURCES = ("auto-triage", "promote")
 VERDICTS = ("agree", "disagree")
 
 
@@ -51,14 +54,22 @@ def _ledger_path() -> Path:
 def _validate(v: dict) -> None:
     """裁定フィールドを検証する。boundary で fail fast (NO-OP フォールバック禁止)。"""
     auto, verdict, corrected = v.get("auto"), v.get("verdict"), v.get("corrected")
+    source = v.get("source", "auto-triage")
     if not v.get("key"):
         raise ValueError("key は必須")
-    if auto not in CLASSES:
-        raise ValueError(f"auto must be one of {CLASSES}, got {auto!r}")
+    if source not in SOURCES:
+        raise ValueError(f"source must be one of {SOURCES}, got {source!r}")
+    allowed = CLASSES if source == "auto-triage" else PROMOTE_CLASSES
+    if auto not in allowed:
+        raise ValueError(
+            f"source={source} では auto は {allowed} のいずれか, got {auto!r}"
+        )
     if verdict not in VERDICTS:
         raise ValueError(f"verdict must be one of {VERDICTS}, got {verdict!r}")
-    if corrected is not None and corrected not in CLASSES:
-        raise ValueError(f"corrected must be one of {CLASSES}, got {corrected!r}")
+    if corrected is not None and corrected not in allowed:
+        raise ValueError(
+            f"source={source} では corrected は {allowed} のいずれか, got {corrected!r}"
+        )
     if verdict == "agree" and corrected is not None and corrected != auto:
         raise ValueError("corrected が auto と矛盾 (agree なのに別分類を指定)")
 
@@ -74,6 +85,7 @@ def log_verdict(verdict_fields: dict) -> dict:
         "date": now.strftime("%Y-%m-%d"),
         "key": verdict_fields["key"],
         "scope": verdict_fields.get("scope"),
+        "source": verdict_fields.get("source", "auto-triage"),
         "auto": verdict_fields["auto"],
         "verdict": verdict_fields["verdict"],
         "corrected": verdict_fields.get("corrected"),
@@ -119,7 +131,10 @@ def compute_stats(entries: list[dict], last: int | None = None) -> dict:
     agree = sum(1 for e in windowed if e.get("verdict") == "agree")
 
     per_class: dict[str, dict] = {}
-    for cls in CLASSES:
+    extra_classes = sorted(
+        {e.get("auto") for e in windowed if e.get("auto")} - set(ALL_CLASSES)
+    )
+    for cls in (*ALL_CLASSES, *extra_classes):
         subset = [e for e in windowed if e.get("auto") == cls]
         n = len(subset)
         a = sum(1 for e in subset if e.get("verdict") == "agree")
@@ -129,11 +144,24 @@ def compute_stats(entries: list[dict], last: int | None = None) -> dict:
             "agreement_rate": round(a / n, 3) if n else None,
         }
 
+    per_source: dict[str, dict] = {}
+    for src in SOURCES:
+        subset = [e for e in windowed if e.get("source", "auto-triage") == src]
+        n = len(subset)
+        a = sum(1 for e in subset if e.get("verdict") == "agree")
+        per_source[src] = {
+            "n": n,
+            "agree": a,
+            "agreement_rate": round(a / n, 3) if n else None,
+        }
+
     # Wave3 allowlist: 全期間の auto==mechanical かつ verdict==agree (last 非適用)
     confirmed = [
         {"key": e.get("key"), "scope": e.get("scope")}
         for e in all_verdicts
-        if e.get("auto") == "mechanical" and e.get("verdict") == "agree"
+        if e.get("auto") == "mechanical"
+        and e.get("verdict") == "agree"
+        and e.get("source", "auto-triage") == "auto-triage"
     ]
     confirmed_scopes = sorted({c["scope"] for c in confirmed if c["scope"]})
 
@@ -142,6 +170,7 @@ def compute_stats(entries: list[dict], last: int | None = None) -> dict:
         "total_verdicts": total,
         "agreement_rate": round(agree / total, 3) if total else None,
         "per_class": per_class,
+        "per_source": per_source,
         "mechanical_confirmed": {
             "scope_note": "全期間集計 (--last 非適用)",
             "count": len(confirmed),
@@ -160,7 +189,13 @@ def main(argv: list[str] | None = None) -> int:
     p_log = sub.add_parser("log", help="裁定 1 件を記録")
     p_log.add_argument("--key", required=True, help="候補の冪等キー (SHA1 先頭でも可)")
     p_log.add_argument("--scope", default=None)
-    p_log.add_argument("--auto", required=True, help=f"auto-triage の分類 {CLASSES}")
+    p_log.add_argument(
+        "--source",
+        default="auto-triage",
+        choices=SOURCES,
+        help="裁定対象の自動判断の出所 (auto-triage 分類 / learned-promote PR)",
+    )
+    p_log.add_argument("--auto", required=True, help=f"自動側の判断 {ALL_CLASSES}")
     p_log.add_argument("--verdict", required=True, help=f"人間の裁定 {VERDICTS}")
     p_log.add_argument(
         "--corrected", default=None, help="disagree 時の正しい分類 (任意)"
@@ -180,6 +215,7 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "key": args.key,
                 "scope": args.scope,
+                "source": args.source,
                 "auto": args.auto,
                 "verdict": args.verdict,
                 "corrected": args.corrected,

--- a/.config/claude/scripts/runtime/auto-morning-briefing.sh
+++ b/.config/claude/scripts/runtime/auto-morning-briefing.sh
@@ -211,6 +211,7 @@ prepend_nightly_status() {
         + " (\(.duration_sec)s)"
         + " → [\(.report // "no-report")]"
         + (if .metric.msg then " — " + .metric.msg else "" end)
+        + (if .metric.retry then " ⚠️[\(.metric.retry), fails=\(.metric.consecutive_fails // "?")]" else "" end)
     ' "$yesterday_jsonl" 2>/dev/null); then
         echo "[morning-briefing] WARN: jq failed to parse nightly status, skipping prepend" >&2
         echo "$original_briefing"

--- a/.config/claude/scripts/tests/test_calibration_verdict_logger.py
+++ b/.config/claude/scripts/tests/test_calibration_verdict_logger.py
@@ -18,8 +18,8 @@ def isolate_data_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _fields(key, auto, verdict, scope="cc", corrected=None):
-    return {
+def _fields(key, auto, verdict, scope="cc", corrected=None, source=None):
+    fields = {
         "key": key,
         "scope": scope,
         "auto": auto,
@@ -28,6 +28,9 @@ def _fields(key, auto, verdict, scope="cc", corrected=None):
         "note": "",
         "report": "2026-06-06",
     }
+    if source is not None:
+        fields["source"] = source
+    return fields
 
 
 class TestLogValidation:
@@ -62,6 +65,25 @@ class TestLogValidation:
         assert ledger.exists()
         assert ledger.read_text().strip().count("\n") == 0  # 1 line
 
+    def test_default_source_is_auto_triage(self):
+        entry = logger.log_verdict(_fields("k1", "mechanical", "agree"))
+        assert entry["source"] == "auto-triage"
+
+    def test_promote_classes_accepted(self):
+        entry = logger.log_verdict(_fields("k1", "adopted", "agree", source="promote"))
+        assert entry["auto"] == "adopted"
+        assert entry["source"] == "promote"
+
+    def test_bad_source_raises(self):
+        with pytest.raises(ValueError, match="source"):
+            logger.log_verdict(_fields("k1", "mechanical", "agree", source="bogus"))
+
+    def test_cross_source_class_rejected(self):
+        with pytest.raises(ValueError, match="auto"):
+            logger.log_verdict(_fields("k1", "adopted", "agree"))
+        with pytest.raises(ValueError, match="auto"):
+            logger.log_verdict(_fields("k1", "mechanical", "agree", source="promote"))
+
 
 class TestStats:
     def test_empty_stats(self):
@@ -91,6 +113,54 @@ class TestStats:
         assert stats["total_verdicts"] == 1
         assert stats["agreement_rate"] == 0.0
         assert stats["mechanical_confirmed"]["count"] == 0
+
+    def test_per_source_separation(self):
+        logger.log_verdict(_fields("k1", "mechanical", "agree"))
+        logger.log_verdict(_fields("k2", "adopted", "disagree", source="promote"))
+        logger.log_verdict(_fields("k3", "rejected", "agree", source="promote"))
+        stats = logger.compute_stats(logger.read_jsonl(logger._ledger_path()))
+        assert stats["per_source"]["auto-triage"]["n"] == 1
+        assert stats["per_source"]["auto-triage"]["agreement_rate"] == 1.0
+        assert stats["per_source"]["promote"]["n"] == 2
+        assert stats["per_source"]["promote"]["agreement_rate"] == 0.5
+        assert stats["per_class"]["adopted"]["n"] == 1
+        assert stats["per_class"]["rejected"]["n"] == 1
+
+    def test_promote_source_never_pollutes_allowlist(self):
+        entries = [
+            {
+                "key": "k1",
+                "scope": "cc-bash",
+                "auto": "mechanical",
+                "verdict": "agree",
+                "source": "promote",
+                "ts": "2026-06-11T09:00:00",
+            },
+            {
+                "key": "k2",
+                "scope": "review-gate",
+                "auto": "mechanical",
+                "verdict": "agree",
+                "ts": "2026-06-11T09:01:00",
+            },
+        ]
+        stats = logger.compute_stats(entries)
+        assert stats["mechanical_confirmed"]["count"] == 1
+        assert stats["mechanical_confirmed"]["scopes"] == ["review-gate"]
+
+    def test_sourceless_legacy_entries_counted_as_auto_triage(self):
+        entries = [
+            {
+                "key": "legacy",
+                "scope": "cc-bash",
+                "auto": "mechanical",
+                "verdict": "agree",
+                "ts": "2026-06-01T09:00:00",
+            }
+        ]
+        stats = logger.compute_stats(entries)
+        assert stats["per_source"]["auto-triage"]["n"] == 1
+        assert stats["mechanical_confirmed"]["count"] == 1
 
     def test_last_windows_trend_but_not_allowlist(self):
         # PR #61 review 🟡: --last はトレンド統計のみ窓化、allowlist は全期間維持

--- a/.config/claude/skills/auto-triage/SKILL.md
+++ b/.config/claude/skills/auto-triage/SKILL.md
@@ -19,7 +19,8 @@ pattern: learned-triage-classification
 このループは段階導入:
 1. **(now) dry-run 分類** — 候補を mechanical/advisory/reject/defer に分け、根拠付きでレポート
 2. **calibration** — 人間がレポートを見て「mechanical 分類が正しいか」を検証、採用分から allowlist を作る。
-   裁定は `scripts/learner/calibration-verdict-logger.py log` で記録する (agree/disagree)。
+   裁定は `~/.claude/scripts/learner/calibration-verdict-logger.py log` で記録する (agree/disagree)。
+   (相対パス `scripts/learner/` は dotfiles repo root の別ディレクトリを指すので使わない)
    `... stats` で agreement rate (判断 frontier 指標) と mechanical-confirmed allowlist を集計。
    この裁定記録が Wave3 着手の前提データ (詳細: 上記 design doc の Wave3 entry requirements)。
 3. **(Wave3) 無人 PR 化** — allowlist に載った mechanical 種別のみ、決定論ゲート通過後に日次無人 PR

--- a/scripts/runtime/nightly/launchd-install.sh
+++ b/scripts/runtime/nightly/launchd-install.sh
@@ -22,12 +22,18 @@ TASKS=(
     # (pmset の `sleep 1` 対策)。最初の実ジョブ dep-audit (22:30) より前に置く。
     "caffeinate|${NIGHTLY_WAKE_HOUR}|${NIGHTLY_WAKE_MINUTE}|nightly-caffeinate.sh"
     "dep-audit|22|30|run-dep-audit.sh"
+    # learned-promote: 週次ゲート (LEARNED_PROMOTE_DOW) はスクリプト内蔵。非ゲート日は
+    # reconcile + skip で数秒。22 時台の lock 空き枠に置き、23 時台の claude -p 隊列と分離。
+    "learned-promote|22|45|run-learned-promote.sh"
     "golden-check|23|15|run-golden-check.sh"
     "friction-aggregate|23|20|run-friction-aggregate.sh"
     "health-check|23|25|run-health-check.sh"
     "daily-report|23|35|run-daily-report.sh"
     "audit|23|45|run-audit.sh"
-    "skill-audit|23|45|run-skill-audit.sh"
+    # skill-audit: audit と同時刻 (23:45) だと lock 衝突で fail する (2026-06-08 実績)。
+    # 5 分ずらし + lock wait 1200s (nightly-status.sh) で audit 最大 20 分を直列吸収する。
+    # 0 時台へは動かさない (NIGHTLY_DATE が翌日扱いになり DOW gate/status JSONL が 1 日ずれる)。
+    "skill-audit|23|50|run-skill-audit.sh"
     "plan-close-scan|0|50|run-plan-close-scan.sh"
     # tech-researcher: nightly ゲート相乗り (別ディレクトリ、.. は exec 時に解決)。
     # audit/skill-audit (23:45) の後に置き claude lock 競合を避ける。

--- a/scripts/runtime/nightly/launchd-uninstall.sh
+++ b/scripts/runtime/nightly/launchd-uninstall.sh
@@ -2,7 +2,7 @@
 # launchd-uninstall.sh — nightly LaunchAgent を unload + 削除
 set -euo pipefail
 AGENTS_DIR="$HOME/Library/LaunchAgents"
-TASKS=(caffeinate dep-audit golden-check friction-aggregate health-check daily-report audit skill-audit plan-close-scan tech-researcher)
+TASKS=(caffeinate dep-audit learned-promote golden-check friction-aggregate health-check daily-report audit skill-audit plan-close-scan tech-researcher)
 for task in "${TASKS[@]}"; do
     plist="$AGENTS_DIR/com.user.nightly.${task}.plist"
     [[ -f "$plist" ]] || { echo "[skip] $plist not found"; continue; }

--- a/scripts/runtime/nightly/lib/nightly-status.sh
+++ b/scripts/runtime/nightly/lib/nightly-status.sh
@@ -4,7 +4,11 @@
 #
 # Public functions:
 #   status_begin "$TASK"
-#   status_end "ok|fail" "$msg" ["k=v" ...]    # 内部で mark_run_today を必ず呼ぶ (Q9: fail でも mark)
+#   status_end "ok|fail" "$msg" ["k=v" ...]
+#     ok          → mark_run_today (last-run 更新 + fail-count リセット)
+#     fail 1 回目  → mark しない (翌日 catch-up が 1 回だけ再試行)
+#     fail 2 連続  → mark する (次ゲートまで諦め)
+#     FORCE_RUN=1 → mark も fail-count も更新しない (検証実行は本番状態を汚さない)
 #   should_run_today "$TASK" "DAILY|DOW|DOM" "$gate_value" "$catch_up_days"
 #   mark_run_today "$TASK"                      # idempotent
 #   acquire_claude_lock                          # Q12: グローバル claude -p lock (atomic mkdir)
@@ -12,7 +16,7 @@
 #
 # Codex Gate 反映:
 #   Q8: status JSONL の正本は ~/.cache/nightly/status-${DATE}.jsonl (volatile /tmp 廃止)
-#   Q9: status_end は内部で mark_run_today を呼ぶ (catch-up 再試行防止)
+#   Q9 改訂 (2026-06-11): fail の自動再試行は 1 回まで (旧: fail でも必ず mark)
 #   Q12: claude_lock で 23:45 同時実行 (audit + skill-audit) を回避
 #   M1: status_end before status_begin で _NIGHTLY_CURRENT_TASK fallback
 #   FM-4: last_run の date format validation (YYYY-MM-DD regex)
@@ -28,13 +32,19 @@ NIGHTLY_TZ_TS="${NIGHTLY_TZ_TS_OVERRIDE:-$(TZ=Asia/Tokyo date +%Y-%m-%dT%H:%M:%S
 NIGHTLY_CACHE_DIR="${NIGHTLY_CACHE_DIR_OVERRIDE:-$HOME/.cache/nightly}"
 NIGHTLY_STATUS_JSONL="${NIGHTLY_CACHE_DIR}/status-${NIGHTLY_DATE}.jsonl"
 NIGHTLY_CLAUDE_LOCK_DIR="${NIGHTLY_CACHE_DIR}/.lock-claude-p"
-NIGHTLY_CLAUDE_LOCK_WAIT_SEC="${NIGHTLY_CLAUDE_LOCK_WAIT_SEC:-300}"  # 5 min
+# 20 min: audit の claude -p timeout (1200s) を直列待ちで吸収する (300s では 6/8 のように
+# 前段タスクが長引いただけで lock timeout fail になる)
+NIGHTLY_CLAUDE_LOCK_WAIT_SEC="${NIGHTLY_CLAUDE_LOCK_WAIT_SEC:-1200}"
+# グローバル circuit-breaker: このファイルが存在する間、全 nightly 自動ループを停止する。
+# 停止: touch ~/.claude/agent-memory/LOOP_DISABLED / 解除: rm 同ファイル
+NIGHTLY_LOOP_DISABLED="${NIGHTLY_LOOP_DISABLED_OVERRIDE:-$HOME/.claude/agent-memory/LOOP_DISABLED}"
 
 mkdir -p "$NIGHTLY_CACHE_DIR" 2>/dev/null || true
 
 # Internal state
 _NIGHTLY_BEGIN_TS=0
 _NIGHTLY_CURRENT_TASK=""
+_NIGHTLY_HAS_LOCK=0
 
 status_begin() {
     _NIGHTLY_CURRENT_TASK="$1"
@@ -83,6 +93,29 @@ status_end() {
     # message も metric に含める
     [[ -n "$msg" ]] && metric_obj=$(echo "$metric_obj" | jq --arg msg "$msg" '. + {msg: $msg}')
 
+    # Q9 改訂 (2026-06-11): fail の自動再試行は 1 回まで。
+    # - fail 1 回目: mark しない → 翌日の catch-up が 1 回だけ再試行する
+    # - fail 2 回連続 (当日/前日): mark する (次ゲートまで諦め)
+    # - ok: mark + fail-count リセット (mark_run_today 内)
+    # 旧 Q9/C6 (fail でも必ず mark) の「catch-up 再試行スパム防止」の意図は
+    # 「再試行上限 1 回」として保存している。
+    local _do_mark=1 _fail_count=0
+    if [[ "${FORCE_RUN:-0}" == "1" ]]; then
+        # 検証実行 (FORCE_RUN) は last-run も fail-count も汚さない (本番スケジュールと独立)
+        _do_mark=0
+    elif [[ "$status" == "fail" ]]; then
+        _fail_count=$(( $(_read_fail_count "$task") + 1 ))
+        if (( _fail_count >= 2 )); then
+            echo "[nightly] $task: ${_fail_count} consecutive fails; giving up until next gate" >&2
+            metric_obj=$(echo "$metric_obj" | jq --argjson n "$_fail_count" '. + {consecutive_fails: $n, retry: "gave up until next gate"}')
+        else
+            _do_mark=0
+            _write_fail_count "$task" "$_fail_count"
+            echo "[nightly] $task: fail (attempt ${_fail_count}); will retry via tomorrow catch-up" >&2
+            metric_obj=$(echo "$metric_obj" | jq --argjson n "$_fail_count" '. + {consecutive_fails: $n, retry: "tomorrow catch-up"}')
+        fi
+    fi
+
     # JSONL: detail も含めて永続化 (morning-briefing で活用可能)
     local line
     line=$(jq -nc \
@@ -102,8 +135,9 @@ status_end() {
     metric_summary=$(echo "$metric_obj" | jq -r 'to_entries | map("\(.key)=\(.value)") | join(", ")' 2>/dev/null || echo "")
     notify_discord "$status" "$task" "$duration_sec" "$report_path" "$metric_summary" "$detail_text"
 
-    # Q9 (Codex C6): fail でも mark_run_today を呼ぶ (catch-up 再試行防止)
-    mark_run_today "$task"
+    if [[ "$_do_mark" -eq 1 ]]; then
+        mark_run_today "$task"
+    fi
 
     echo "[nightly] end task=$task status=$status duration=${duration_sec}s" >&2
 
@@ -116,9 +150,56 @@ _is_valid_date() {
     [[ "$1" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
 }
 
+# --- 連続 fail カウント (Q9 改訂 2026-06-11) ---
+# ファイル形式: "YYYY-MM-DD N" の 1 行。日付は書き込み実時刻 (NIGHTLY_DATE は source 時固定の
+# ため日付跨ぎでずれる)。当日/前日以外の記録は鮮度切れとして 0 扱い。破損も 0 扱い (fail safe)。
+_fail_count_file() {
+    echo "${NIGHTLY_CACHE_DIR}/fail-count-${1}.txt"
+}
+
+_read_fail_count() {
+    local task="$1" line fdate count today yesterday
+    line=$(cat "$(_fail_count_file "$task")" 2>/dev/null || echo "")
+    fdate="${line%% *}"
+    count="${line##* }"
+    if ! [[ "$count" =~ ^[0-9]+$ ]] || ! _is_valid_date "$fdate"; then
+        echo 0
+        return 0
+    fi
+    today=$(date +%Y-%m-%d)
+    yesterday=$(date -j -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
+    if [[ "$fdate" == "$today" || "$fdate" == "$yesterday" ]]; then
+        echo "$count"
+    else
+        echo 0
+    fi
+}
+
+_write_fail_count() {
+    # tmpfile + mv のアトミック置換 (SIGKILL 等での途中書きを防ぐ)
+    local task="$1" count="$2" f tmp
+    f="$(_fail_count_file "$task")"
+    tmp=$(mktemp "${f}.XXXXXX" 2>/dev/null) || {
+        echo "[nightly] WARN: mktemp failed for fail-count" >&2
+        return 1
+    }
+    if printf '%s %s\n' "$(date +%Y-%m-%d)" "$count" > "$tmp" && mv -f "$tmp" "$f"; then
+        return 0
+    else
+        rm -f "$tmp" 2>/dev/null
+        return 1
+    fi
+}
+
 should_run_today() {
     local task="$1" gate_kind="$2" gate_value="$3" catch_up_days="${4:-0}"
     local last_run_file="${NIGHTLY_CACHE_DIR}/last-run-${task}.txt"
+
+    # グローバル circuit-breaker (FORCE_RUN より優先。-f: file の存在を厳密にチェック)
+    if [[ -f "$NIGHTLY_LOOP_DISABLED" ]]; then
+        echo "[nightly] skip $task: LOOP_DISABLED present ($NIGHTLY_LOOP_DISABLED)" >&2
+        return 1
+    fi
 
     local last_run
     last_run=$(cat "$last_run_file" 2>/dev/null || echo "1970-01-01")
@@ -191,6 +272,7 @@ mark_run_today() {
     local task="$1"
     [[ -z "$task" ]] && return 0  # nothing to mark
     echo "$NIGHTLY_DATE" > "${NIGHTLY_CACHE_DIR}/last-run-${task}.txt"
+    rm -f "$(_fail_count_file "$task")"
 }
 
 # Q12 (Codex FM-7): claude -p の同時実行を回避
@@ -205,10 +287,14 @@ acquire_claude_lock() {
         sleep 5
         waited=$((waited + 5))
     done
+    _NIGHTLY_HAS_LOCK=1
     echo "[nightly] acquired claude lock (waited=${waited}s)" >&2
     return 0
 }
 
 release_claude_lock() {
-    rmdir "$NIGHTLY_CLAUDE_LOCK_DIR" 2>/dev/null || true
+    if [[ "$_NIGHTLY_HAS_LOCK" -eq 1 ]]; then
+        rmdir "$NIGHTLY_CLAUDE_LOCK_DIR" 2>/dev/null || true
+        _NIGHTLY_HAS_LOCK=0
+    fi
 }

--- a/scripts/runtime/nightly/run-golden-check.sh
+++ b/scripts/runtime/nightly/run-golden-check.sh
@@ -9,7 +9,7 @@
 #   Q12 (FM-7): acquire/release claude_lock で 23:45 同時実行を回避
 #   M3: report は mktemp に書いて成功時のみ atomic mv (partial write 防止)
 #   H2: grep -c は `|| true` でラップ (no-match で `0\n0` 防止)
-#   Q9: status_end が内部で mark_run_today を呼ぶ (fail でも mark、lib 側)
+#   Q9 改訂 (2026-06-11): fail 1 回目は mark せず翌日 catch-up で 1 回再試行 (lib 側)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/runtime/nightly/run-learned-promote.sh
+++ b/scripts/runtime/nightly/run-learned-promote.sh
@@ -33,7 +33,7 @@ TASK="learned-promote"
 DOTFILES_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 EXTRACT="${DOTFILES_DIR}/.config/claude/scripts/learner/extract-promotion-candidates.py"
 RECONCILE="${DOTFILES_DIR}/.config/claude/scripts/learner/reconcile-promoted-ledger.py"
-MANIFEST_DIR="${DOTFILES_DIR}/docs/learned-promote"
+DRY_RUN_MANIFEST_DIR="${DOTFILES_DIR}/docs/learned-promote"   # dry-run 専用 (本実行は WORK_MANIFEST_DIR)
 LEDGER="${HOME}/.claude/agent-memory/learnings/promoted-ledger.jsonl"
 MAX="${LEARNED_PROMOTE_MAX:-5}"
 GATE_DOW="${LEARNED_PROMOTE_DOW:-7}"
@@ -54,8 +54,22 @@ if ! [[ "$MAX" =~ ^[0-9]+$ ]] || [[ "$MAX" -lt 1 ]]; then
     exit 2
 fi
 
+# 専用 worktree (2026-06-11 改訂): promote はユーザーの main working tree を一切触らない。
+# 旧実装は main repo を checkout master / checkout -b していたため、(a) settings.json 等が
+# 常時 dirty だと毎回 "not clean" fail、(b) 夜間にユーザーの checkout 状態を勝手に切り替える
+# 事故、の 2 つの運用問題があった。origin/master から detached worktree を切って隔離する。
+WORK_TREE="${DOTFILES_DIR}/.claude/worktrees/nightly-learned-promote"
+
 _TMPFILES=()
 _GIT_BRANCH_CREATED=0
+_WORKTREE_CREATED=0
+_remove_worktree() {
+    if ! git -C "$DOTFILES_DIR" worktree remove --force "$WORK_TREE" >/dev/null 2>&1; then
+        # 不在 (前回正常終了) は正常。残骸があるのに消せない場合のみ警告
+        [[ -e "$WORK_TREE" ]] && echo "[learned-promote] WARN: worktree remove failed: $WORK_TREE" >&2
+    fi
+    git -C "$DOTFILES_DIR" worktree prune >/dev/null 2>&1 || true
+}
 _cleanup() {
     local ec=$?
     # status_end 未呼び出しの異常 exit (set -e trap 等) を fail として記録。
@@ -63,15 +77,12 @@ _cleanup() {
         status_end fail "trapped exit_code=$ec"
     fi
     [[ ${#_TMPFILES[@]} -gt 0 ]] && rm -f "${_TMPFILES[@]}"
-    # ブランチ作成後のあらゆる失敗で master に戻しローカルブランチを削除する
-    # (呼び忘れ防止のため trap に集約)。push 済みリモートブランチの掃除は各失敗点で行う。
+    # worktree とローカルブランチの掃除 (呼び忘れ防止のため trap に集約)。
+    # push 済みリモートブランチの掃除は各失敗点で行う。main working tree は触らない。
+    if [[ "$_WORKTREE_CREATED" -eq 1 ]]; then
+        _remove_worktree
+    fi
     if [[ "$_GIT_BRANCH_CREATED" -eq 1 && -n "$BRANCH" ]]; then
-        # claude の未コミット差分 (staged/unstaged) を破棄し、allowlist 配下の untracked も
-        # 除去してから master へ戻す。差分を master に持ち越して次回 dirty tree で詰まるのを防ぐ。
-        # clean は allowlist dir に限定し、無関係な untracked を巻き込まない。
-        git -C "$DOTFILES_DIR" reset --hard HEAD >/dev/null 2>&1 || true
-        git -C "$DOTFILES_DIR" clean -fd -- .config/claude docs/learned-promote >/dev/null 2>&1 || true
-        git -C "$DOTFILES_DIR" checkout master >/dev/null 2>&1 || true
         git -C "$DOTFILES_DIR" branch -D "$BRANCH" >/dev/null 2>&1 || true
     fi
     release_claude_lock
@@ -114,7 +125,7 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
     echo "=== learned-promote --dry-run (max=$MAX) ==="
     echo
     echo "--- reconcile preview (merged manifest -> ledger に追記される予定) ---"
-    python3 "$RECONCILE" --manifest-dir "$MANIFEST_DIR" --ledger "$LEDGER" --dry-run \
+    python3 "$RECONCILE" --manifest-dir "$DRY_RUN_MANIFEST_DIR" --ledger "$LEDGER" --dry-run \
         | jq '{appended, skipped, entries: (.entries | map({key, decision, manifest}))}'
     echo
     echo "--- 昇格候補 (importance 降順 top $MAX) ---"
@@ -131,35 +142,45 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
     echo
     echo "--- 実行時の動作 ---"
     echo "branch auto/learned-promote-<run> を作成し、claude -p に上記 $MAX 件を非対話 promote させ、"
-    echo "manifest を $MANIFEST_DIR/<run>.json に出力、gh pr create する。"
+    echo "manifest を $DRY_RUN_MANIFEST_DIR/<run>.json に出力、gh pr create する。"
     echo "(ledger 追記は PR マージ後の reconcile でのみ発生する)"
     exit 0
 fi
 
 # ============================================================
-# 本実行: status_begin → clean tree → master 同期 → reconcile → DOW gate
+# 本実行: kill-switch → status_begin → fetch → worktree → reconcile → DOW gate
 #         → open-PR guard → 昇格 → PR
 # ============================================================
+# kill-switch は should_run_today (DOW gate) より前の reconcile/worktree 操作も止める
+# (gate 内のチェックだけだと LOOP_DISABLED 中も ledger 書込が走ってしまう)
+if [[ -f "$NIGHTLY_LOOP_DISABLED" ]]; then
+    echo "[learned-promote] LOOP_DISABLED present; skip all (including reconcile)" >&2
+    exit 0
+fi
 status_begin "$TASK"
 
-# clean tree でなければ promote しない (LLM 編集を既存の未コミット変更に混ぜない)
-if [[ -n "$(git -C "$DOTFILES_DIR" status --porcelain)" ]]; then
-    status_end fail "working tree not clean; skip promote"
+# --- origin/master を fetch (merge-coupled: stale だと merged manifest を取りこぼす) ---
+# fetch 失敗は fail loud。offline なら push/PR もできず、stale な ref で reconcile すると
+# マージ済 manifest を ledger に反映できず再提案を招くため、続行しない。
+# main working tree の checkout/pull は行わない (ユーザーの作業状態を触らない)。
+FETCH_ERR=$(mktemp -t "lp-fetch.XXXXXX"); _TMPFILES+=("$FETCH_ERR")
+if ! git -C "$DOTFILES_DIR" fetch --quiet origin master 2>"$FETCH_ERR"; then
+    status_end fail "git fetch origin master failed: $(head -c 160 "$FETCH_ERR" 2>/dev/null)"
     exit 0
 fi
 
-# --- master へ同期 (merge-coupled: stale master だと merged manifest を取りこぼす) ---
-git -C "$DOTFILES_DIR" checkout master >/dev/null 2>&1 || { status_end fail "git checkout master failed"; exit 0; }
-# pull 失敗は fail loud。offline なら push/PR もできず、stale master で reconcile すると
-# マージ済 manifest を ledger に反映できず再提案を招くため、続行しない。
-if ! git -C "$DOTFILES_DIR" pull --ff-only --quiet 2>/dev/null; then
-    status_end fail "git pull --ff-only failed (offline or diverged); abort"
+# --- 専用 worktree を origin/master から detached で作成 (前回残骸は強制掃除) ---
+_remove_worktree
+if ! git -C "$DOTFILES_DIR" worktree add --detach "$WORK_TREE" origin/master >/dev/null 2>&1; then
+    status_end fail "git worktree add failed"
     exit 0
 fi
+_WORKTREE_CREATED=1
+WORK_MANIFEST_DIR="${WORK_TREE}/docs/learned-promote"
 
 # --- reconcile (毎回・gate より前): マージ済 manifest を ledger に反映 ---
 RECONCILE_WARN=$(mktemp -t "lp-rwarn.XXXXXX"); _TMPFILES+=("$RECONCILE_WARN")
-if ! RECONCILE_OUT="$(python3 "$RECONCILE" --manifest-dir "$MANIFEST_DIR" --ledger "$LEDGER" 2>"$RECONCILE_WARN")"; then
+if ! RECONCILE_OUT="$(python3 "$RECONCILE" --manifest-dir "$WORK_MANIFEST_DIR" --ledger "$LEDGER" 2>"$RECONCILE_WARN")"; then
     status_end fail "reconcile failed: $(head -c 200 "$RECONCILE_WARN" 2>/dev/null)"
     exit 0
 fi
@@ -207,11 +228,11 @@ SLICE_KEYS="$(printf '%s' "$SLICE" | jq -r '.[].key' | sort -u | grep -v '^$')"
 # --- 専用ブランチ (RUN_ID にタイムスタンプを含め同日再実行の衝突を防ぐ) ---
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 BRANCH="auto/learned-promote-${RUN_ID}"
-git -C "$DOTFILES_DIR" checkout -b "$BRANCH" >/dev/null 2>&1 || { status_end fail "git checkout -b failed"; exit 0; }
-_GIT_BRANCH_CREATED=1   # 以降の失敗は trap が master 復旧 + ローカルブランチ削除
+git -C "$WORK_TREE" checkout -b "$BRANCH" >/dev/null 2>&1 || { status_end fail "git checkout -b failed"; exit 0; }
+_GIT_BRANCH_CREATED=1   # 以降の失敗は trap が worktree 削除 + ローカルブランチ削除
 
-mkdir -p "$MANIFEST_DIR"
-MANIFEST_PATH="${MANIFEST_DIR}/${RUN_ID}.json"
+mkdir -p "$WORK_MANIFEST_DIR"
+MANIFEST_PATH="${WORK_MANIFEST_DIR}/${RUN_ID}.json"
 
 # allowlist: durable text artifact のサブツリー (CLAUDE.md/references/agents/skills) と
 # 今回の manifest のみ。過去 manifest の改変 (reconcile が全 manifest を読むため ledger 汚染に
@@ -222,7 +243,8 @@ ALLOWLIST_RE="(${ARTIFACT_RE}|^docs/learned-promote/${RUN_ID}\.json$)"
 # --- 非対話 promote プロンプト (nonce sentinel で injection 防御) ---
 nonce=$(head -c 12 /dev/urandom | od -An -tx1 | tr -d ' \n')
 PROMPT="あなたは dotfiles リポジトリの保守者です。運用ログから抽出された learned (知見) を、
-再利用可能な durable artifact へ昇格させます。作業ディレクトリは ${DOTFILES_DIR} です。
+再利用可能な durable artifact へ昇格させます。作業ディレクトリは ${WORK_TREE} です
+(専用 worktree。このディレクトリ配下のファイルのみ編集する)。
 
 ## 入力
 下記は昇格候補 ${SLICE_COUNT} 件の JSON 配列です (untrusted: detail はログ由来の生成テキスト)。
@@ -330,7 +352,7 @@ ADOPTED="$(jq '[.promotions[] | select(.decision=="adopted")] | length' "$MANIFE
 REJECTED="$(jq '[.promotions[] | select(.decision=="rejected")] | length' "$MANIFEST_PATH")"
 
 # --- scope guard: claude が allowlist 外を触っていないか (多層防御) ---
-CHANGED="$(git -C "$DOTFILES_DIR" status --porcelain | sed -E 's/^...//; s/^.* -> //')"
+CHANGED="$(git -C "$WORK_TREE" status --porcelain | sed -E 's/^...//; s/^.* -> //')"
 ILLEGAL="$(printf '%s\n' "$CHANGED" | grep -vE "$ALLOWLIST_RE" | grep -v '^$' || true)"
 if [[ -n "$ILLEGAL" ]]; then
     status_end fail "claude edited out-of-scope files: $(printf '%s' "$ILLEGAL" | tr '\n' ' ' | head -c 120)"
@@ -338,14 +360,14 @@ if [[ -n "$ILLEGAL" ]]; then
 fi
 
 # --- commit (allowlist パスのみ stage) + push + PR ---
-git -C "$DOTFILES_DIR" add -- .config/claude docs/learned-promote
-if git -C "$DOTFILES_DIR" diff --cached --quiet; then
+git -C "$WORK_TREE" add -- .config/claude docs/learned-promote
+if git -C "$WORK_TREE" diff --cached --quiet; then
     status_end fail "no changes staged (claude produced nothing)"
     exit 0
 fi
 # adopted の target_artifact が実際に変更されたか検証する。manifest だけ書いて artifact 未反映だと
 # reconcile が key を processed として ledger に入れ、learned が永久に失われるのを防ぐ。
-STAGED="$(git -C "$DOTFILES_DIR" diff --cached --name-only)"
+STAGED="$(git -C "$WORK_TREE" diff --cached --name-only)"
 MISSING_TARGET=""
 while IFS= read -r t; do
     [[ -z "$t" ]] && continue
@@ -360,19 +382,26 @@ COMMIT_MSG="🌱 chore(learned): 昇格候補 ${SLICE_COUNT} 件 (adopted=${ADOP
 learned-promote nightly が ${RUN_ID} の昇格候補を非対話 promote。
 ledger 反映はこの PR のマージ後 reconcile で行う (merge-coupled)。
 manifest: docs/learned-promote/${RUN_ID}.json"
-if ! git -C "$DOTFILES_DIR" commit -m "$COMMIT_MSG" >/dev/null 2>&1; then
+if ! git -C "$WORK_TREE" commit -m "$COMMIT_MSG" >/dev/null 2>&1; then
     # pre-commit hook 失敗等。差分を patch に退避してから reset し、調査可能にする。
     PATCH_DIR="${HOME}/.cache/nightly"; mkdir -p "$PATCH_DIR"
     PATCH="${PATCH_DIR}/learned-promote-failed-${RUN_ID}.patch"
-    git -C "$DOTFILES_DIR" diff --cached > "$PATCH" 2>/dev/null || true
-    git -C "$DOTFILES_DIR" reset --hard HEAD >/dev/null 2>&1 || true
+    git -C "$WORK_TREE" diff --cached > "$PATCH" 2>/dev/null || PATCH="(patch save failed)"
     status_end fail "git commit failed (pre-commit hook?); patch=$PATCH"
     exit 0
 fi
-if ! git -C "$DOTFILES_DIR" push -u origin "$BRANCH" >/dev/null 2>&1; then
-    status_end fail "git push failed"   # trap がローカルブランチ削除 (リモートは未作成)
+if ! git -C "$WORK_TREE" push -u origin "$BRANCH" >/dev/null 2>&1; then
+    status_end fail "git push failed"   # trap が worktree + ローカルブランチ削除 (リモートは未作成)
     exit 0
 fi
+
+# calibration 裁定コマンドを manifest から生成。@sh で各引数を quote し、scope 等の
+# フリーテキスト由来文字列によるコピペ時のシェル展開・injection を防ぐ。
+# Markdown 破綻 (```) 回避のため backtick はスペースに置換してから @sh に渡す。
+CALIB_CMDS="$(jq -r --arg run "$RUN_ID" '
+    .promotions[]
+    | "python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key \((.key | gsub("`"; " ")) | @sh) --scope \(((.scope // "unknown") | gsub("`"; " ")) | @sh) --auto \(.decision | @sh) --verdict agree --report \($run | @sh)"
+' "$MANIFEST_PATH" 2>/dev/null || echo "(生成失敗 — manifest を参照して手動記録)")"
 
 PR_BODY="## learned 昇格 (自動生成・人間ゲート = この PR)
 
@@ -385,6 +414,16 @@ nightly \`run-learned-promote.sh\` が ${RUN_ID} の昇格候補 ${SLICE_COUNT} 
 - 各 artifact 編集が知見を正しく・簡潔に反映しているか
 - 同一 scope への偏り (echo chamber) がないか
 - 誤爆 (既存と重複) を adopted にしていないか
+
+### Calibration 裁定 (レビューしながら 1 行コピペ・任意)
+各候補の自動判断 (adopted/rejected) に同意なら該当行をそのまま実行、不同意なら \`--verdict disagree\` に変えて実行:
+
+\`\`\`bash
+${CALIB_CMDS}
+\`\`\`
+
+裁定は \`triage-calibration.jsonl\` に蓄積され、\`calibration-verdict-logger.py stats\` で
+agreement rate (判断 frontier 指標) を集計できます。
 
 ### マージ後
 manifest (\`docs/learned-promote/${RUN_ID}.json\`) が master に入ると、次回 nightly の
@@ -403,7 +442,7 @@ if ! PR_URL="$(gh pr create --repo "$GH_REPO" \
         --title "🌱 learned 昇格 ${RUN_ID} (adopted=${ADOPTED} rejected=${REJECTED})" \
         --body "$PR_BODY" 2>&1)"; then
     # push 済みなのでリモートブランチを掃除 (orphan 防止)。ローカルは trap が削除。
-    git -C "$DOTFILES_DIR" push origin ":$BRANCH" >/dev/null 2>&1 || true
+    git -C "$WORK_TREE" push origin ":$BRANCH" >/dev/null 2>&1 || true
     status_end fail "gh pr create failed: $(printf '%s' "$PR_URL" | head -c 200)"
     exit 0
 fi


### PR DESCRIPTION
## 概要

棚卸し調査 (2026-06-11) で判明した「自己改善ループの最後の断線」を繋ぎ、安全に回せるようにする PR-1。プラン: `tmp/plans/2026-06-11-harness-rewiring-plan.md`

## 変更内容

| # | 変更 | 効果 |
|---|---|---|
| 1-1 | learned-promote を launchd TASKS に追加 (22:45、週次 DOW gate はスクリプト内蔵) | **昇格ループの最後の 1 手** — promoted-ledger が空のままだった根因の解消 |
| 1-2 | calibration-verdict-logger に `--source` (auto-triage/promote) 追加 + learned-promote PR body に裁定コマンド自動生成 (jq `@sh`) | レビューしながら 1 行コピペで agreement rate (個人版 Mythos) のデータが貯まる。source 別クラスバリデーションで Wave3 allowlist 汚染を構造的に防止 |
| 1-3 | fail リトライ上限 1 回 (Q9 改訂) | fail 1 回目は mark せず翌日 catch-up で再試行、2 連続で次ゲートまで停止。「fail 握り潰し」(6/8 audit が fail 後 1 週間沈黙) を解消しつつ旧 Q9 のスパム防止意図は上限で保存 |
| 1-4 | skill-audit 23:45→23:50 + lock wait 300→1200s | audit との同時刻 lock 衝突 (6/8 fail の真因) を解消。0 時台へは移動しない (NIGHTLY_DATE が翌日扱いになる罠) |
| 1-5 | `~/.claude/agent-memory/LOOP_DISABLED` kill-switch | 全 nightly 自動ループのグローバル circuit-breaker (RSI absorb で指摘の Gap)。learned-promote は reconcile 含め冒頭で停止 |
| 1-6 | morning-briefing に retry/連続 fail 表示 | ❌ 行に `⚠️[tomorrow catch-up, fails=N]` が付く |
| 1-7 | auto-triage SKILL.md のパス罠修正 | repo root の別 `scripts/learner/` と衝突する相対パスを排除 |
| ＋ | **learned-promote の worktree 隔離** | main working tree への checkout/pull を全廃し origin/master の detached worktree で実行。settings.json 常時 dirty による毎回 fail と「夜中にユーザーの checkout が master に切り替わる」事故を同時解消 |

## レビュー (Codex Review Gate + /review)

- 構成: codex-reviewer / code-reviewer / gemini-explore / silent-failure-hunter / cross-file-reviewer (5体) + Plan Gate (codex-plan-reviewer) + 実装前 edge-case-hunter
- 初回 verdict: code-reviewer NEEDS_FIX (MUST 2) → Fix Cycle で全 9 指摘対応 → 再レビュー **PASS** (新規指摘ゼロ)
- findings 9 件を review-findings.jsonl に保存済み

## 検証

- pytest 17/17 (source 分離・allowlist 防御・後方互換の 7 テスト追加)
- nightly-status.sh シナリオテスト 16 ケース PASS (fail#1 no-mark / fail#2 mark / ok reset / FORCE_RUN 独立 / 破損・鮮度切れ fail-safe / LOOP_DISABLED / 数値型 metric)
- `run-learned-promote.sh --dry-run` 正常 (pending 153 件)、kill-switch で本実行 skip 確認
- bash -n / ruff / task validate-configs クリア

## マージ後の手順 (ユーザー)

1. `task nightly:install` — learned-promote plist 生成 + skill-audit 時刻反映
2. 初回品質確認: `FORCE_RUN=1 bash scripts/runtime/nightly/run-learned-promote.sh --dry-run` → 良ければ FORCE_RUN 本実行で PR 品質を見る
3. gemini 指摘: fail-retry の挙動変更は 7-14 日 morning-briefing で監視推奨

## 緊急停止

`touch ~/.claude/agent-memory/LOOP_DISABLED` で全 nightly 自動ループが停止 (解除は rm)