### PR TITLE
🔧 chore(config): validate-symlinks を self-rewriting app 設計に同期 + worktrees を git ignore

### DIFF
--- a/.bin/validate_symlinks.sh
+++ b/.bin/validate_symlinks.sh
@@ -33,14 +33,16 @@ managed_links = [
     (home / ".claude/skills", root / ".config/claude/skills", ".claude/skills"),
 
     # block 3: Codex
-    (home / ".codex/config.toml", root / ".codex/config.toml", ".codex/config.toml"),
+    # NOTE: .codex/config.toml は symlink 検証対象外 — Codex.app/cmux が起動時に自己書き換え
+    # するため nix/home/default.nix で home.file 管理外 (self-rewriting app パターン)。
     (home / ".codex/AGENTS.md", root / ".codex/AGENTS.md", ".codex/AGENTS.md"),
 
     # block 4: Gemini
     (home / ".gemini/GEMINI.md", root / ".gemini/GEMINI.md", ".gemini/GEMINI.md"),
 
     # block 5: Cursor
-    (home / ".cursor/hooks.json", root / ".cursor/hooks.json", ".cursor/hooks.json"),
+    # NOTE: .cursor/hooks.json は symlink 検証対象外 — cmux が起動時に自己書き換えするため
+    # nix/home/default.nix で home.file 管理外 (.codex/config.toml と同じパターン)。
     (home / ".cursor/rules", root / ".cursor/rules", ".cursor/rules"),
     (home / ".cursor/skills", root / ".cursor/skills", ".cursor/skills"),
     (home / ".cursor/agents", root / ".cursor/agents", ".cursor/agents"),

--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -15,3 +15,4 @@
 .env.local
 
 **/.claude/settings.local.json
+**/.claude/worktrees/


### PR DESCRIPTION
## 概要

PR #80 の flag 2 件のフォローアップ。

## 変更内容

### validate-symlinks の恒常 fail 解消
`.codex/config.toml` / `.cursor/hooks.json` の「missing symlink」fail は、**実は設計済みの状態**だった:
- `nix/home/default.nix` は両ファイルを「Codex.app / cmux が起動時に自己書き換えするため home.file 管理外 (symlink にすると nix:switch が clobber する self-rewriting app パターン)」と明記して symlink 管理から除外済み
- `validate_symlinks.sh` 側にだけ古い期待 (symlink であるべき) が残存し fail し続けていた

→ 検証スクリプトを nix 側の設計判断に同期 (2 エントリ除去 + 理由コメント)。**symlink 復元は棄却** — アプリが再び実ファイル化するため。

実ファイル側の内容は機密 grep (token/key/secret) ゼロを確認済み (Codex.app の mcp_servers/plugins/marketplaces/trust hash と cmux の hook 注入のみ)。

### git ignore に worktrees 追加
`**/.claude/worktrees/` — main repo working tree にあったユーザーのローカル変更を取り込み (worktree 運用でネストした worktree ディレクトリを ignore)。

## 検証
- 修正版 `validate_symlinks.sh` 実行で missing symlink 0 件 (worktree 実行による wrong target は ROOT_DIR 差異の偽エラー、マージ後 main repo で最終確認)
- 7 行の変更 (レビュー省略規模、Verify 実施済み)