### PR TITLE
🔧 chore(memory-vec): indexer ソースを dotfiles 管理化 + nix deploy (P0)

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -195,7 +195,6 @@
     ],
     "disableBypassPermissionsMode": "disable"
   },
-  "model": "claude-fable-5[1m]",
   "enableAllProjectMcpServers": false,
   "enabledMcpjsonServers": [
     "context7",

--- a/.config/claude/skill-data/memory-vec/.gitignore
+++ b/.config/claude/skill-data/memory-vec/.gitignore
@@ -1,0 +1,7 @@
+# memory-vec runtime — version the source, ignore generated/installed artifacts.
+# Source (versioned): reindex.ts, query.ts, package.json, pnpm-lock.yaml, lib/memory_redactor.py
+node_modules/
+index.db
+index.db.tmp
+.reindex.lock
+lib/__pycache__/

--- a/.config/claude/skill-data/memory-vec/README.md
+++ b/.config/claude/skill-data/memory-vec/README.md
@@ -1,0 +1,32 @@
+# memory-vec runtime
+
+agent-memory + Obsidian Vault 記事を埋め込みインデックス化し、意味検索でオンデマンド参照するためのランタイム。
+
+- `reindex.ts` — `index.db` をフル再構築（DROP→CREATE→全 md を redact→embed）。stop-hook が `index.db` の mtime < ソース md の mtime のとき background 起動する。
+- `query.ts` — クエリを embed して KNN 検索。`recall` skill / SessionStart hint hook が呼ぶ。
+- `lib/memory_redactor.py` — embed 前に秘匿情報を redact（`.config/claude/scripts/lib/redactor.py` と重複の疑いあり。統合は別タスク）。
+
+呼び出し元は `~/.claude/scripts/runtime/memory-vec-{stop,hint}-hook.py`（`node <path>` を直接実行。`pnpm run` は経由しない）。
+
+## デプロイ（nix home-manager）
+
+ソース（`*.ts` / `package.json` / `pnpm-lock.yaml` / `lib/memory_redactor.py`）は dotfiles git 管理下にあり、`nix/home/default.nix` の `outLink`（mkOutOfStoreSymlink）で個別ファイル symlink される。`node_modules/` と `index.db` は生成物（gitignore）で、このディレクトリ内にローカル実体として共存する。
+
+## 新規 PC セットアップ
+
+1. `task nix:switch` — ソース 5 ファイルが `~/.claude/skill-data/memory-vec/` に symlink される。
+2. `cd ~/.claude/skill-data/memory-vec && pnpm install` — `node_modules/`（gitignore）を再現。
+3. 初回 reindex は stop-hook が自動起動する（または `pnpm run reindex` で手動）。
+
+## 一回限りの移行注意（このリポジトリを既に未管理運用していたマシンのみ）
+
+ソースが未バージョン管理（実ファイル）だったマシンでは、初回 `nix:switch` の**前に**既存実体を削除すること（home-manager が既存実ファイルと symlink で衝突するため）:
+
+```bash
+cd ~/.claude/skill-data/memory-vec
+rm reindex.ts query.ts package.json pnpm-lock.yaml lib/memory_redactor.py
+# node_modules/ と index.db は残す（生成物）
+task nix:switch   # ~/dotfiles で実行
+```
+
+新規 PC では実体が存在しないため、この削除は不要。

--- a/.config/claude/skill-data/memory-vec/lib/memory_redactor.py
+++ b/.config/claude/skill-data/memory-vec/lib/memory_redactor.py
@@ -1,0 +1,43 @@
+"""Phase A wrapper around .config/claude/scripts/lib/redactor.redact().
+
+Permanent location for Phase C (Stop hook reindex). Moved out of the spike
+worktree so the reindex script can import it independently.
+
+This module MUST NOT modify redactor.py itself — it only delegates.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# Resolve the existing redactor library inside the dotfiles repo.
+# ~/.claude/ is a symlink to dotfiles/.config/claude/, so .scripts/lib lives there.
+_LIB_DIR = Path.home() / ".claude" / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from redactor import MASK, redact  # type: ignore  # noqa: E402
+
+
+class RedactStats(NamedTuple):
+    text: str
+    bytes_in: int
+    bytes_out: int
+    redaction_count: int
+
+
+def redact_for_embedding(text: str) -> str:
+    return redact(text)
+
+
+def redact_with_stats(text: str) -> RedactStats:
+    bytes_in = len(text.encode("utf-8"))
+    out = redact(text)
+    return RedactStats(
+        text=out,
+        bytes_in=bytes_in,
+        bytes_out=len(out.encode("utf-8")),
+        redaction_count=out.count(MASK),
+    )

--- a/.config/claude/skill-data/memory-vec/package.json
+++ b/.config/claude/skill-data/memory-vec/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "memory-vec-runtime",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "reindex": "node --experimental-strip-types --no-warnings $HOME/.claude/skill-data/memory-vec/reindex.ts",
+    "query": "node --experimental-strip-types --no-warnings $HOME/.claude/skill-data/memory-vec/query.ts"
+  },
+  "dependencies": {
+    "@xenova/transformers": "^2.17.2",
+    "sqlite-vec": "^0.1.6"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["sharp", "onnxruntime-node"]
+  }
+}

--- a/.config/claude/skill-data/memory-vec/pnpm-lock.yaml
+++ b/.config/claude/skill-data/memory-vec/pnpm-lock.yaml
@@ -1,0 +1,707 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@xenova/transformers':
+        specifier: ^2.17.2
+        version: 2.17.2
+      sqlite-vec:
+        specifier: ^0.1.6
+        version: 0.1.9
+
+packages:
+
+  '@huggingface/jinja@0.2.2':
+    resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
+    engines: {node: '>=18'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@xenova/transformers@2.17.2':
+    resolution: {integrity: sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  flatbuffers@1.12.0:
+    resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
+
+  node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onnx-proto@4.0.4:
+    resolution: {integrity: sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==}
+
+  onnxruntime-common@1.14.0:
+    resolution: {integrity: sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==}
+
+  onnxruntime-node@1.14.0:
+    resolution: {integrity: sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.14.0:
+    resolution: {integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  protobufjs@6.11.6:
+    resolution: {integrity: sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==}
+    hasBin: true
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.32.6:
+    resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
+    engines: {node: '>=14.15.0'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
+
+  sqlite-vec-darwin-arm64@0.1.9:
+    resolution: {integrity: sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sqlite-vec-darwin-x64@0.1.9:
+    resolution: {integrity: sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==}
+    cpu: [x64]
+    os: [darwin]
+
+  sqlite-vec-linux-arm64@0.1.9:
+    resolution: {integrity: sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==}
+    cpu: [arm64]
+    os: [linux]
+
+  sqlite-vec-linux-x64@0.1.9:
+    resolution: {integrity: sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==}
+    cpu: [x64]
+    os: [linux]
+
+  sqlite-vec-windows-x64@0.1.9:
+    resolution: {integrity: sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==}
+    cpu: [x64]
+    os: [win32]
+
+  sqlite-vec@0.1.9:
+    resolution: {integrity: sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+snapshots:
+
+  '@huggingface/jinja@0.2.2': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
+  '@types/long@4.0.2': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@xenova/transformers@2.17.2':
+    dependencies:
+      '@huggingface/jinja': 0.2.2
+      onnxruntime-web: 1.14.0
+      sharp: 0.32.6
+    optionalDependencies:
+      onnxruntime-node: 1.14.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  b4a@1.8.1: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.2)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.1(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
+
+  base64-js@1.5.1: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  chownr@1.1.4: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  detect-libc@2.1.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  expand-template@2.0.3: {}
+
+  fast-fifo@1.3.2: {}
+
+  flatbuffers@1.12.0: {}
+
+  fs-constants@1.0.0: {}
+
+  github-from-package@0.0.0: {}
+
+  guid-typescript@1.0.9: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  is-arrayish@0.3.4: {}
+
+  long@4.0.0: {}
+
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-addon-api@6.1.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onnx-proto@4.0.4:
+    dependencies:
+      protobufjs: 6.11.6
+
+  onnxruntime-common@1.14.0: {}
+
+  onnxruntime-node@1.14.0:
+    dependencies:
+      onnxruntime-common: 1.14.0
+    optional: true
+
+  onnxruntime-web@1.14.0:
+    dependencies:
+      flatbuffers: 1.12.0
+      guid-typescript: 1.0.9
+      long: 4.0.0
+      onnx-proto: 4.0.4
+      onnxruntime-common: 1.14.0
+      platform: 1.3.6
+
+  platform@1.3.6: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  protobufjs@6.11.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/long': 4.0.2
+      '@types/node': 25.6.0
+      long: 4.0.0
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  safe-buffer@5.2.1: {}
+
+  semver@7.7.4: {}
+
+  sharp@0.32.6:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      node-addon-api: 6.1.0
+      prebuild-install: 7.1.3
+      semver: 7.7.4
+      simple-get: 4.0.1
+      tar-fs: 3.1.2
+      tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
+
+  sqlite-vec-darwin-arm64@0.1.9:
+    optional: true
+
+  sqlite-vec-darwin-x64@0.1.9:
+    optional: true
+
+  sqlite-vec-linux-arm64@0.1.9:
+    optional: true
+
+  sqlite-vec-linux-x64@0.1.9:
+    optional: true
+
+  sqlite-vec-windows-x64@0.1.9:
+    optional: true
+
+  sqlite-vec@0.1.9:
+    optionalDependencies:
+      sqlite-vec-darwin-arm64: 0.1.9
+      sqlite-vec-darwin-x64: 0.1.9
+      sqlite-vec-linux-arm64: 0.1.9
+      sqlite-vec-linux-x64: 0.1.9
+      sqlite-vec-windows-x64: 0.1.9
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  undici-types@7.19.2: {}
+
+  util-deprecate@1.0.2: {}
+
+  wrappy@1.0.2: {}

--- a/.config/claude/skill-data/memory-vec/query.ts
+++ b/.config/claude/skill-data/memory-vec/query.ts
@@ -1,0 +1,84 @@
+// query.ts (Phase D)
+//
+// CLI: node --experimental-strip-types query.ts <query-text>
+// Outputs JSON array on stdout: [{ path, name, distance }, ...]
+//
+// Located alongside node_modules/ (same reason as reindex.ts).
+
+import { DatabaseSync } from "node:sqlite";
+import * as sqliteVec from "sqlite-vec";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pipeline, env } from "@xenova/transformers";
+
+env.allowLocalModels = false;
+env.useBrowserCache = false;
+
+const DB_PATH = join(homedir(), ".claude/skill-data/memory-vec/index.db");
+const EMBED_MODEL = "Xenova/all-MiniLM-L6-v2";
+const TOP_K = 5;
+
+function openDB(path: string): DatabaseSync {
+	const db = new DatabaseSync(path, { allowExtension: true });
+	db.enableLoadExtension(true);
+	sqliteVec.load(db);
+	db.enableLoadExtension(false);
+	return db;
+}
+
+let extractor: Awaited<ReturnType<typeof pipeline>> | null = null;
+
+async function embed(text: string): Promise<Float32Array> {
+	if (!extractor) {
+		extractor = await pipeline("feature-extraction", EMBED_MODEL);
+	}
+	const out = (await extractor(text, {
+		pooling: "mean",
+		normalize: true,
+	})) as unknown as { data: Float32Array };
+	return new Float32Array(out.data);
+}
+
+async function main(): Promise<void> {
+	const query = process.argv[2];
+	if (!query || !query.trim()) {
+		process.exit(2);
+	}
+
+	const db = openDB(DB_PATH);
+	try {
+		const qEmb = await embed(query);
+		const blob = new Uint8Array(qEmb.buffer, qEmb.byteOffset, qEmb.byteLength);
+		const rows = db
+			.prepare(
+				`SELECT d.name, d.path, v.distance
+         FROM doc_vec AS v
+         JOIN docs AS d ON d.id = v.rowid
+         WHERE v.embedding MATCH ? AND v.k = ?
+         ORDER BY v.distance ASC
+         LIMIT ?`,
+			)
+			.all(blob, TOP_K, TOP_K) as {
+			name: string;
+			path: string;
+			distance: number;
+		}[];
+
+		process.stdout.write(
+			JSON.stringify(
+				rows.map((r) => ({
+					path: r.path,
+					name: r.name,
+					distance: r.distance,
+				})),
+			),
+		);
+	} finally {
+		db.close();
+	}
+}
+
+main().catch((e: unknown) => {
+	process.stderr.write(`memory-vec-query: ${String(e)}\n`);
+	process.exit(1);
+});

--- a/.config/claude/skill-data/memory-vec/reindex.ts
+++ b/.config/claude/skill-data/memory-vec/reindex.ts
@@ -1,0 +1,395 @@
+// reindex.ts (Phase C, post-review hardened)
+//
+// Full rebuild of ./index.db from memory/*.md with the following safeguards
+// (added after multi-reviewer pass that flagged CRITICAL/HIGH risks):
+//
+//   - Single-flight via .reindex.lock (CRITICAL: concurrent DROP TABLE race)
+//   - Atomic rebuild via index.db.tmp -> rename (CRITICAL: empty-DB residue
+//     when DDL succeeds but population fails)
+//   - Sentinel touch even on failure (CRITICAL: infinite retry loop when
+//     rebuild fails before utimes)
+//   - Per-file try/catch (HIGH: one unreadable file kills entire reindex)
+//   - clean === "" skip (HIGH: zero-vector pollution from over-redacted file)
+//   - redact_with_stats anomaly detection (HIGH: dead-code wrapper, no
+//     defense-in-depth signal)
+//   - Log stack/error with redact() applied (HIGH: traceback leaks raw text)
+//
+// Located alongside node_modules/ so ESM resolver finds @xenova/transformers
+// and sqlite-vec without NODE_PATH gymnastics.
+
+import { DatabaseSync } from "node:sqlite";
+import * as sqliteVec from "sqlite-vec";
+import {
+	appendFileSync,
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	utimesSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import { pipeline, env } from "@xenova/transformers";
+
+env.allowLocalModels = false;
+env.useBrowserCache = false;
+
+const HOME = homedir();
+const MEMORY_DIR = join(
+	HOME,
+	".claude/projects/-Users-takeuchishougo-dotfiles/memory",
+);
+const SKILL_DATA = join(HOME, ".claude/skill-data/memory-vec");
+const DB_PATH = join(SKILL_DATA, "index.db");
+const DB_TMP = join(SKILL_DATA, "index.db.tmp");
+const LOCK_PATH = join(SKILL_DATA, ".reindex.lock");
+const LOG_FILE = join(HOME, ".claude/logs/memory-vec.log");
+const REDACTOR_LIB = join(SKILL_DATA, "lib");
+const EMBED_MODEL = "Xenova/all-MiniLM-L6-v2";
+const DIM = 384;
+const ANOMALY_BYTES_FLOOR = 1024;
+const STALE_LOCK_SEC = 600;
+
+mkdirSync(SKILL_DATA, { recursive: true });
+
+const REDACT_SCRUB_HELPER = `
+import sys
+sys.path.insert(0, ${JSON.stringify(REDACTOR_LIB)})
+from memory_redactor import redact_for_embedding
+sys.stdout.write(redact_for_embedding(sys.stdin.read()))
+`;
+
+function scrubForLog(text: string): string {
+	// Best-effort redaction of error/traceback text via the same helper used
+	// for embedding input. Failure leaves the original (logging is best-effort).
+	try {
+		return execFileSync("python3", ["-c", REDACT_SCRUB_HELPER], {
+			input: text,
+			encoding: "utf8",
+			maxBuffer: 1 * 1024 * 1024,
+			timeout: 1500,
+		});
+	} catch {
+		return text.length > 500 ? `${text.slice(0, 500)}... [truncated]` : text;
+	}
+}
+
+function logFailure(stage: string, err: unknown): void {
+	try {
+		mkdirSync(join(HOME, ".claude/logs"), { recursive: true });
+		const errMsg =
+			err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+		const stack = err instanceof Error && err.stack ? err.stack : undefined;
+		const entry = {
+			ts: new Date().toISOString(),
+			source: "memory-vec-reindex",
+			stage,
+			error: scrubForLog(errMsg),
+			stack: stack ? scrubForLog(stack) : undefined,
+		};
+		appendFileSync(LOG_FILE, JSON.stringify(entry) + "\n", "utf8");
+	} catch (logErr) {
+		process.stderr.write(
+			`memory-vec-reindex: log write failed: ${String(logErr)}\n`,
+		);
+	}
+}
+
+type LockHandle = { fd: number };
+
+function acquireLock(): LockHandle | null {
+	// Reap stale lock (process killed mid-reindex)
+	if (existsSync(LOCK_PATH)) {
+		try {
+			const ageSec = (Date.now() - statSync(LOCK_PATH).mtimeMs) / 1000;
+			if (ageSec > STALE_LOCK_SEC) {
+				rmSync(LOCK_PATH, { force: true });
+			}
+		} catch (e) {
+			logFailure("lock_stale_check", e);
+		}
+	}
+	try {
+		const fd = openSync(LOCK_PATH, "wx");
+		return { fd };
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+			return null;
+		}
+		logFailure("lock_acquire", e);
+		return null;
+	}
+}
+
+function releaseLock(lock: LockHandle): void {
+	try {
+		closeSync(lock.fd);
+	} catch (e) {
+		logFailure("lock_close", e);
+	}
+	try {
+		rmSync(LOCK_PATH, { force: true });
+	} catch (e) {
+		logFailure("lock_remove", e);
+	}
+}
+
+function touchSentinel(target: string): void {
+	// Touch DB mtime so the Stop hook treats the index as "freshly attempted",
+	// even on failure — prevents infinite retry when memory mtime > db mtime.
+	try {
+		if (existsSync(target)) {
+			const now = new Date();
+			utimesSync(target, now, now);
+		}
+	} catch (e) {
+		logFailure("touch_sentinel", e);
+	}
+}
+
+const REDACT_HELPER = `
+import sys
+sys.path.insert(0, ${JSON.stringify(REDACTOR_LIB)})
+from memory_redactor import redact_with_stats
+text = sys.stdin.read()
+stats = redact_with_stats(text)
+sys.stdout.write(f"{stats.redaction_count}\\t{stats.bytes_in}\\t{stats.bytes_out}\\n")
+sys.stdout.write(stats.text)
+`;
+
+type RedactResult = {
+	text: string;
+	bytesIn: number;
+	bytesOut: number;
+	redactionCount: number;
+} | null;
+
+function redactWithStats(text: string): RedactResult {
+	let raw: string;
+	try {
+		raw = execFileSync("python3", ["-c", REDACT_HELPER], {
+			input: text,
+			encoding: "utf8",
+			maxBuffer: 50 * 1024 * 1024,
+		});
+	} catch (e) {
+		logFailure("redact", e);
+		return null;
+	}
+	const newlineIdx = raw.indexOf("\n");
+	if (newlineIdx < 0) {
+		logFailure("redact_parse", new Error("missing header line"));
+		return null;
+	}
+	const header = raw.slice(0, newlineIdx);
+	const body = raw.slice(newlineIdx + 1);
+	const parts = header.split("\t");
+	if (parts.length !== 3) {
+		logFailure("redact_parse", new Error(`bad header: ${header.slice(0, 80)}`));
+		return null;
+	}
+	return {
+		text: body,
+		redactionCount: Number(parts[0]),
+		bytesIn: Number(parts[1]),
+		bytesOut: Number(parts[2]),
+	};
+}
+
+function openDB(path: string): DatabaseSync {
+	const db = new DatabaseSync(path, { allowExtension: true });
+	db.enableLoadExtension(true);
+	sqliteVec.load(db);
+	db.enableLoadExtension(false);
+	return db;
+}
+
+let extractor: Awaited<ReturnType<typeof pipeline>> | null = null;
+
+async function getExtractor(): Promise<Awaited<ReturnType<typeof pipeline>>> {
+	if (!extractor) {
+		extractor = await pipeline("feature-extraction", EMBED_MODEL);
+	}
+	return extractor;
+}
+
+async function embed(text: string): Promise<Float32Array> {
+	const ex = await getExtractor();
+	const out = (await ex(text, {
+		pooling: "mean",
+		normalize: true,
+	})) as unknown as {
+		data: Float32Array;
+	};
+	return new Float32Array(out.data);
+}
+
+type DocFile = { path: string; name: string; body: string };
+
+function readMemoryFiles(): DocFile[] {
+	let files: string[];
+	try {
+		files = readdirSync(MEMORY_DIR).filter((f: string) => f.endsWith(".md"));
+	} catch (e) {
+		logFailure("readdir_memory", e);
+		return [];
+	}
+	const out: DocFile[] = [];
+	for (const f of files) {
+		const path = join(MEMORY_DIR, f);
+		try {
+			out.push({ path, name: f, body: readFileSync(path, "utf8") });
+		} catch (e) {
+			logFailure(`read_file:${f}`, e);
+		}
+	}
+	return out;
+}
+
+async function rebuildIndex(
+	dbPath: string,
+): Promise<{ indexed: number; skipped: number; anomalies: number }> {
+	const db = openDB(dbPath);
+	try {
+		db.exec(`DROP TABLE IF EXISTS docs`);
+		db.exec(`DROP TABLE IF EXISTS doc_vec`);
+		db.exec(`
+      CREATE TABLE docs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL,
+        body TEXT NOT NULL
+      );
+    `);
+		db.exec(
+			`CREATE VIRTUAL TABLE doc_vec USING vec0(embedding FLOAT[${DIM}]);`,
+		);
+
+		const insertDoc = db.prepare(
+			`INSERT INTO docs (name, path, body) VALUES (?, ?, ?) RETURNING id`,
+		);
+		const insertVec = db.prepare(
+			`INSERT INTO doc_vec (rowid, embedding) VALUES (?, ?)`,
+		);
+
+		const docs = readMemoryFiles();
+		let indexed = 0;
+		let skipped = 0;
+		let anomalies = 0;
+		for (const d of docs) {
+			const stats = redactWithStats(d.body);
+			if (stats === null) {
+				skipped++;
+				continue;
+			}
+			const clean = stats.text;
+			if (!clean.trim()) {
+				skipped++;
+				continue;
+			}
+			if (stats.bytesIn > ANOMALY_BYTES_FLOOR && stats.bytesOut === 0) {
+				// Defense-in-depth: redactor returned empty for non-trivial input.
+				// Skip rather than embed a zero-signal vector.
+				anomalies++;
+				skipped++;
+				continue;
+			}
+			try {
+				const emb = await embed(clean.slice(0, 2000));
+				const inserted = insertDoc.get(d.name, d.path, clean) as { id: number };
+				insertVec.run(
+					BigInt(inserted.id),
+					new Uint8Array(emb.buffer, emb.byteOffset, emb.byteLength),
+				);
+				indexed++;
+			} catch (e) {
+				logFailure(`embed_insert:${d.name}`, e);
+				skipped++;
+			}
+		}
+		return { indexed, skipped, anomalies };
+	} finally {
+		db.close();
+	}
+}
+
+async function main(): Promise<void> {
+	const tStart = performance.now();
+	const lock = acquireLock();
+	if (!lock) {
+		appendFileSync(
+			LOG_FILE,
+			JSON.stringify({
+				ts: new Date().toISOString(),
+				source: "memory-vec-reindex",
+				stage: "lock_held",
+				note: "another reindex in progress; this run is a no-op",
+			}) + "\n",
+			"utf8",
+		);
+		return;
+	}
+	try {
+		// Atomic rebuild: write into tmp, rename to final on success.
+		if (existsSync(DB_TMP)) {
+			try {
+				rmSync(DB_TMP, { force: true });
+			} catch (e) {
+				logFailure("tmp_cleanup_pre", e);
+			}
+		}
+
+		let stats: { indexed: number; skipped: number; anomalies: number };
+		try {
+			stats = await rebuildIndex(DB_TMP);
+		} catch (e) {
+			logFailure("rebuild", e);
+			try {
+				rmSync(DB_TMP, { force: true });
+			} catch (cleanErr) {
+				logFailure("tmp_cleanup_post_fail", cleanErr);
+			}
+			// Touch existing DB so Stop hook does not retry forever on persistent failure.
+			touchSentinel(DB_PATH);
+			return;
+		}
+
+		try {
+			renameSync(DB_TMP, DB_PATH);
+		} catch (e) {
+			logFailure("rename", e);
+			touchSentinel(DB_PATH);
+			return;
+		}
+		touchSentinel(DB_PATH);
+
+		appendFileSync(
+			LOG_FILE,
+			JSON.stringify({
+				ts: new Date().toISOString(),
+				source: "memory-vec-reindex",
+				stage: "complete",
+				indexed: stats.indexed,
+				skipped: stats.skipped,
+				anomalies: stats.anomalies,
+				elapsed_ms: Math.round(performance.now() - tStart),
+			}) + "\n",
+			"utf8",
+		);
+	} finally {
+		releaseLock(lock);
+	}
+}
+
+main().catch((e) => {
+	logFailure("unhandled", e);
+	touchSentinel(DB_PATH);
+	process.exitCode = 1;
+});

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -68,6 +68,17 @@ in
     ".claude/workflows"            = outLink ".config/claude/workflows";
     ".claude/references"           = outLink ".config/claude/references";
 
+    # block 2b: memory-vec indexer source (個別ファイル symlink)。
+    # skill-data/memory-vec/ は node_modules/index.db (ローカル生成物, gitignore) が
+    # 同居するため dir 単位ではなく個別ファイルを symlink (real dir は維持)。
+    # 注意: nix:switch 前に ~/.claude/skill-data/memory-vec/ の実体 .ts/.json/.yaml/lib を
+    # 削除すること (home-manager が既存実ファイルと衝突するため)。node_modules/index.db は残す。
+    ".claude/skill-data/memory-vec/reindex.ts"             = outLink ".config/claude/skill-data/memory-vec/reindex.ts";
+    ".claude/skill-data/memory-vec/query.ts"               = outLink ".config/claude/skill-data/memory-vec/query.ts";
+    ".claude/skill-data/memory-vec/package.json"           = outLink ".config/claude/skill-data/memory-vec/package.json";
+    ".claude/skill-data/memory-vec/pnpm-lock.yaml"         = outLink ".config/claude/skill-data/memory-vec/pnpm-lock.yaml";
+    ".claude/skill-data/memory-vec/lib/memory_redactor.py" = outLink ".config/claude/skill-data/memory-vec/lib/memory_redactor.py";
+
     # block 3: Codex (.codex → ~/.codex)
     # NOTE: .codex/config.toml は Codex.app/cmux が起動時に自己書き換え (notify / node_repl
     # MCP / plugins / marketplaces / hooks trust hash を注入) するため home.file 管理外。


### PR DESCRIPTION
## Summary

memory-vec の indexer ソース (`reindex.ts` / `query.ts` / `package.json` / `pnpm-lock.yaml` / `lib/memory_redactor.py`) を `~/.claude/skill-data/memory-vec/` の **未バージョン管理** 状態から dotfiles git 管理下 (`.config/claude/skill-data/memory-vec/`) へ移行。

- nix home-manager の `outLink` (mkOutOfStoreSymlink) で **個別ファイル symlink** デプロイ。`node_modules/` と `index.db` は生成物なので gitignore し、real dir 内にローカル共存させる
- stale だった `package.json` scripts のパス (`scripts/runtime/memory-vec-*.ts` = 不在) を実在 skill-data パスに修正
- runtime README 追加 (新規 PC setup の `pnpm install` 手順 + 一回限りの移行注意)

**背景**: indexer ソースがどこにもバージョン管理されておらず (`~/.claude/skill-data/` が消えたらコードも消える脆さ)、worktree 隔離もレビューも不能だった。これは memory-vec を Obsidian Vault 記事索引に拡張する後続タスク (P3) の前提整備。

`.ts`/`.py`/`pnpm-lock.yaml` は既存本番稼働コードの verbatim コピー (commit 時 lefthook フォーマッタが indentation を tab に整形、ロジックは byte 同一)。

## ⚠️ マージ後の必須手順 (このマシンのみ・一回限り)

home-manager が既存実ファイルと衝突するため、`nix:switch` の**前に**実体を削除する:

\`\`\`bash
cd ~/.claude/skill-data/memory-vec
rm reindex.ts query.ts package.json pnpm-lock.yaml lib/memory_redactor.py
# node_modules/ と index.db は残す (生成物)
cd ~/dotfiles && task nix:switch
\`\`\`

新規 PC では実体が無いため削除不要 (README に記載)。

## Review

`/review` (code-reviewer + security-reviewer 並列) → **PASS**。
- 機密混入なし / .gitignore 生成物除外を実証 / symlink hijack ベクターなし
- [IMPORTANT] 移行手順の durable 化 → README 追加で解消済
- codex 3-way は CLI 到達不能のため明示スキップ

## Test plan

- [x] `nix flake check` 通過 (darwinConfigurations.private/work eval OK)
- [x] commit に生成物 (node_modules/index.db) 混入なし
- [ ] マージ後: 上記削除手順 → `task nix:switch` → symlink 解決確認 (`ls -l ~/.claude/skill-data/memory-vec/reindex.ts` が dotfiles を指す)
- [ ] マージ後: `node reindex.ts` 実行 (node_modules/index.db 健在、reindex 成功)