### PR TITLE
✨ feat(nightly): 夜間バッチの LLM 呼び出しを claude -p → codex に移行

### DIFF
--- a/scripts/runtime/nightly/launchd-install.sh
+++ b/scripts/runtime/nightly/launchd-install.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # launchd-install.sh — nightly task の launchd LaunchAgent plist を生成 + load
-# 理由: cron は Aqua session 外で起動 → Keychain access 不可 → claude -p が Execution error で fail
-# launchd LaunchAgent (~/Library/LaunchAgents/) は user の Aqua session 内で起動 → Keychain OK
+# 理由: cron は Aqua session 外 + PATH/env が最小で起動するため LLM CLI が不安定。
+# launchd LaunchAgent (~/Library/LaunchAgents/) は user の Aqua session 内で起動し、
+# EnvironmentVariables で PATH/HOME/TZ/モデル設定を明示注入できる。
+# (2026-06-14: 夜間 LLM 呼び出しは claude -p → codex に移行済。codex は CODEX_HOME 認証)
 set -euo pipefail
 
 NIGHTLY_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -10,10 +12,14 @@ mkdir -p "$AGENTS_DIR"
 
 VAULT_PATH="${OBSIDIAN_VAULT_PATH:-$HOME/Documents/Obsidian Vault}"
 
-# 夜間バッチの claude -p は Sonnet に固定する。--model 無指定の claude -p は
-# ~/.claude/settings.json のデフォルトモデルに従うため、対話用に Fable/Opus へ
-# 切り替えるとバッチ 23 箇所のコストと挙動が暗黙に変わってしまう (2026-06-11 検出)。
-NIGHTLY_CLAUDE_MODEL="${NIGHTLY_CLAUDE_MODEL:-claude-sonnet-4-6}"
+# 夜間バッチの LLM 呼び出しは 2026-06-14 に claude -p → codex へ移行。codex は CODEX_HOME 認証で
+# headless 安定 (claude -p の default model / Keychain 依存の不安定を回避)。モデルと推論強度を
+# 明示固定する (env で上書き可。run-*.sh / lib も同じ既定にフォールバックする)。
+# CODEX_HOME を明示注入し headless で認証経路を確定させる (未注入だと OPENAI_API_KEY 等への
+# 暗黙フォールバックで挙動がぶれる)。
+NIGHTLY_CODEX_MODEL="${NIGHTLY_CODEX_MODEL:-gpt-5.5}"
+NIGHTLY_CODEX_EFFORT="${NIGHTLY_CODEX_EFFORT:-high}"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 
 # wake/caffeinate 時刻の単一真実源 (setup-nightly-wake.sh の pmset と揃える)
 # shellcheck source=./nightly-wake.env
@@ -69,10 +75,14 @@ generate_plist() {
         <string>${HOME}</string>
         <key>TZ</key>
         <string>Asia/Tokyo</string>
+        <key>CODEX_HOME</key>
+        <string>${CODEX_HOME}</string>
         <key>OBSIDIAN_VAULT_PATH</key>
         <string>${VAULT_PATH}</string>
-        <key>NIGHTLY_CLAUDE_MODEL</key>
-        <string>${NIGHTLY_CLAUDE_MODEL}</string>
+        <key>NIGHTLY_CODEX_MODEL</key>
+        <string>${NIGHTLY_CODEX_MODEL}</string>
+        <key>NIGHTLY_CODEX_EFFORT</key>
+        <string>${NIGHTLY_CODEX_EFFORT}</string>
     </dict>
     <key>StandardOutPath</key>
     <string>/tmp/nightly-${task}.launchd.log</string>
@@ -121,8 +131,10 @@ generate_orchestrator_plist() {
         <key>PATH</key><string>/Applications/cmux.app/Contents/Resources/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key><string>${HOME}</string>
         <key>TZ</key><string>Asia/Tokyo</string>
+        <key>CODEX_HOME</key><string>${CODEX_HOME}</string>
         <key>OBSIDIAN_VAULT_PATH</key><string>${VAULT_PATH}</string>
-        <key>NIGHTLY_CLAUDE_MODEL</key><string>${NIGHTLY_CLAUDE_MODEL}</string>
+        <key>NIGHTLY_CODEX_MODEL</key><string>${NIGHTLY_CODEX_MODEL}</string>
+        <key>NIGHTLY_CODEX_EFFORT</key><string>${NIGHTLY_CODEX_EFFORT}</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/runtime/nightly/lib/nightly-status.sh
+++ b/scripts/runtime/nightly/lib/nightly-status.sh
@@ -349,3 +349,50 @@ release_claude_lock() {
         _NIGHTLY_HAS_LOCK=0
     fi
 }
+
+# ============================================================
+# Codex runtime (2026-06-14: 夜間 LLM 呼び出しを claude -p → codex に移行)
+# ------------------------------------------------------------
+# 理由: launchd 直叩きの claude -p は default model / Keychain 依存で不安定
+# (fable-5 classifier outage 等)。codex exec は CODEX_HOME 認証で headless 安定。
+#
+# 出力分離: codex の stdout は reasoning trace なので、最終メッセージは -o で
+# 専用ファイルに書き出す (claude -p は stdout=本文だったため redirect で取れた)。
+# プロンプトは stdin 経由で渡す (positional arg だと stdin EOF 待ちで hang する —
+# 2026-06-14 実地確認)。
+#
+# モデル/推論強度は env で上書き可:
+#   NIGHTLY_CODEX_MODEL  (既定 gpt-5.5)
+#   NIGHTLY_CODEX_EFFORT (既定 high — golden パイロットで検証済)
+# ============================================================
+NIGHTLY_CODEX_MODEL="${NIGHTLY_CODEX_MODEL:-gpt-5.5}"
+NIGHTLY_CODEX_EFFORT="${NIGHTLY_CODEX_EFFORT:-high}"
+
+# run_codex_report — read-only 分析 → レポート生成の共通ラッパー (claude -p 置換)。
+# Usage: run_codex_report <timeout_sec> <out_file> <prompt>
+#   最終メッセージを -o で <out_file> に書く。codex の trace は捨てる。
+# 戻り値: 成功 0 / 失敗 非0。失敗時はグローバル CODEX_ERR_HEAD に trace 先頭 200B。
+# timeout は TIMEOUT_BIN (呼び出し側 preflight で解決済) を使う。未解決なら自前で探す。
+CODEX_ERR_HEAD=""
+run_codex_report() {
+    local timeout_sec="$1" out_file="$2" prompt="$3"
+    local tbin="${TIMEOUT_BIN:-}"
+    [[ -z "$tbin" ]] && tbin=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
+    if [[ -z "$tbin" ]]; then
+        CODEX_ERR_HEAD="timeout/gtimeout not found"
+        return 1
+    fi
+    local trace
+    trace=$(mktemp -t "nightly-codex-trace.XXXXXX")
+    if ! printf '%s' "$prompt" | "$tbin" "${timeout_sec}s" codex exec \
+            --skip-git-repo-check -m "$NIGHTLY_CODEX_MODEL" --sandbox read-only \
+            --config model_reasoning_effort="$NIGHTLY_CODEX_EFFORT" \
+            -o "$out_file" > "$trace" 2>&1; then
+        CODEX_ERR_HEAD=$(head -c 200 "$trace" 2>/dev/null || echo "")
+        rm -f "$trace"
+        return 1
+    fi
+    rm -f "$trace"
+    CODEX_ERR_HEAD=""
+    return 0
+}

--- a/scripts/runtime/nightly/run-audit.sh
+++ b/scripts/runtime/nightly/run-audit.sh
@@ -22,7 +22,7 @@ if [[ -z "${OBSIDIAN_VAULT_PATH:-}" ]]; then
     status_begin "$TASK"; status_end fail "missing OBSIDIAN_VAULT_PATH"
     exit 0
 fi
-for cmd in jq claude; do
+for cmd in jq codex; do
     if ! command -v "$cmd" &>/dev/null; then
         status_begin "$TASK"; status_end fail "preflight: $cmd CLI not found"
         exit 0
@@ -83,14 +83,11 @@ PROMPT="$(cat <<'PROMPT_EOF'
 PROMPT_EOF
 )"
 
-STDERR_LOG=$(mktemp -t "nightly-audit-stderr.XXXXXX")
-if ! "$TIMEOUT_BIN" 1200s claude -p "$PROMPT" --model "${NIGHTLY_CLAUDE_MODEL:-claude-sonnet-4-6}" > "$REPORT_TMP" 2> "$STDERR_LOG"; then
-    err_head=$(head -c 200 "$STDERR_LOG" 2>/dev/null || echo "")
-    rm -f "$STDERR_LOG"
-    status_end fail "claude -p failed/timeout, stderr: $err_head"
+# codex exec (read-only 分析 → -o で REPORT_TMP に最終メッセージのみ書き出す)
+if ! run_codex_report 1200 "$REPORT_TMP" "$PROMPT"; then
+    status_end fail "codex failed/timeout: $CODEX_ERR_HEAD"
     exit 0
 fi
-rm -f "$STDERR_LOG"
 
 mv "$REPORT_TMP" "$REPORT_PATH"
 

--- a/scripts/runtime/nightly/run-daily-report.sh
+++ b/scripts/runtime/nightly/run-daily-report.sh
@@ -29,7 +29,7 @@ if [[ -z "${OBSIDIAN_VAULT_PATH:-}" ]]; then
     status_begin "$TASK"; status_end fail "missing OBSIDIAN_VAULT_PATH"
     exit 0
 fi
-for cmd in jq claude; do
+for cmd in jq codex; do
     if ! command -v "$cmd" &>/dev/null; then
         status_begin "$TASK"; status_end fail "preflight: $cmd CLI not found"
         exit 0
@@ -197,14 +197,11 @@ ${FRICTION_TODAY:-(なし)}
 PROMPT_EOF
 )"
 
-STDERR_LOG=$(mktemp -t "nightly-daily-stderr.XXXXXX")
-if ! "$TIMEOUT_BIN" 600s claude -p "$PROMPT" --model "${NIGHTLY_CLAUDE_MODEL:-claude-sonnet-4-6}" > "$REPORT_TMP" 2> "$STDERR_LOG"; then
-    err_head=$(head -c 200 "$STDERR_LOG" 2>/dev/null || echo "")
-    rm -f "$STDERR_LOG"
-    status_end fail "claude -p failed/timeout, stderr: $err_head"
+# codex exec (read-only 分析 → -o で REPORT_TMP に最終メッセージのみ書き出す)
+if ! run_codex_report 600 "$REPORT_TMP" "$PROMPT"; then
+    status_end fail "codex failed/timeout: $CODEX_ERR_HEAD"
     exit 0
 fi
-rm -f "$STDERR_LOG"
 
 mv "$REPORT_TMP" "$REPORT_PATH"
 

--- a/scripts/runtime/nightly/run-golden-check.sh
+++ b/scripts/runtime/nightly/run-golden-check.sh
@@ -34,7 +34,7 @@ if [[ -z "${OBSIDIAN_VAULT_PATH:-}" ]]; then
     status_begin "$TASK"; status_end fail "missing OBSIDIAN_VAULT_PATH"
     exit 0
 fi
-for cmd in jq curl claude; do
+for cmd in jq curl codex; do
     if ! command -v "$cmd" &>/dev/null; then
         status_begin "$TASK"; status_end fail "preflight: $cmd CLI not found in PATH"
         exit 0
@@ -99,14 +99,11 @@ dotfiles リポ (~/dotfiles) の以下のディレクトリを横断スキャン
 PROMPT_EOF
 )"
 
-STDERR_LOG=$(mktemp -t "nightly-golden-stderr.XXXXXX")
-if ! "$TIMEOUT_BIN" 600s claude -p "$PROMPT" --model "${NIGHTLY_CLAUDE_MODEL:-claude-sonnet-4-6}" > "$REPORT_TMP" 2> "$STDERR_LOG"; then
-    local_stderr_head=$(head -c 200 "$STDERR_LOG" 2>/dev/null || echo "")
-    rm -f "$STDERR_LOG"
-    status_end fail "claude -p failed or timeout, stderr: $local_stderr_head"
+# codex exec (read-only 分析 → -o で REPORT_TMP に最終メッセージのみ書き出す)
+if ! run_codex_report 600 "$REPORT_TMP" "$PROMPT"; then
+    status_end fail "codex failed or timeout: $CODEX_ERR_HEAD"
     exit 0
 fi
-rm -f "$STDERR_LOG"
 
 # M3: 成功時のみ atomic mv
 mv "$REPORT_TMP" "$REPORT_PATH"

--- a/scripts/runtime/nightly/run-health-check.sh
+++ b/scripts/runtime/nightly/run-health-check.sh
@@ -23,7 +23,7 @@ if [[ -z "${OBSIDIAN_VAULT_PATH:-}" ]]; then
     status_begin "$TASK"; status_end fail "missing OBSIDIAN_VAULT_PATH"
     exit 0
 fi
-for cmd in jq claude; do
+for cmd in jq codex; do
     if ! command -v "$cmd" &>/dev/null; then
         status_begin "$TASK"; status_end fail "preflight: $cmd CLI not found"
         exit 0
@@ -84,14 +84,11 @@ ${STALE_DOCS:-(なし)}
 PROMPT_EOF
 )"
 
-STDERR_LOG=$(mktemp -t "nightly-health-stderr.XXXXXX")
-if ! "$TIMEOUT_BIN" 600s claude -p "$PROMPT" --model "${NIGHTLY_CLAUDE_MODEL:-claude-sonnet-4-6}" > "$REPORT_TMP" 2> "$STDERR_LOG"; then
-    err_head=$(head -c 200 "$STDERR_LOG" 2>/dev/null || echo "")
-    rm -f "$STDERR_LOG"
-    status_end fail "claude -p failed/timeout, stderr: $err_head"
+# codex exec (read-only 分析 → -o で REPORT_TMP に最終メッセージのみ書き出す)
+if ! run_codex_report 600 "$REPORT_TMP" "$PROMPT"; then
+    status_end fail "codex failed/timeout: $CODEX_ERR_HEAD"
     exit 0
 fi
-rm -f "$STDERR_LOG"
 
 mv "$REPORT_TMP" "$REPORT_PATH"
 

--- a/scripts/runtime/nightly/run-learned-promote.sh
+++ b/scripts/runtime/nightly/run-learned-promote.sh
@@ -106,7 +106,7 @@ for f in "$EXTRACT" "$RECONCILE"; do
 done
 TIMEOUT_BIN=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
 if [[ "$DRY_RUN" -eq 0 ]]; then
-    for cmd in claude gh; do
+    for cmd in codex gh; do
         if ! command -v "$cmd" &>/dev/null; then
             status_begin "$TASK"; status_end fail "preflight: $cmd not found"
             exit 0
@@ -289,13 +289,18 @@ ${MANIFEST_PATH} を Write で次の JSON にする。入力候補 ${SLICE_COUNT
   ]
 }"
 
-# --- claude -p (最小権限: Read/Edit/Write/Glob/Grep。Bash/ネットなし) ---
+# --- codex workspace-write (専用 worktree 配下のみ書込可。下の codex 起動を参照) ---
 if ! acquire_claude_lock; then
-    status_end fail "claude lock timeout"
+    status_end fail "codex lock timeout"
     exit 0
 fi
-# ledger 改ざん検出用に claude 実行前の hash を記録 (claude は Write で任意 path を書ける)
+# ledger 改ざん検出用に codex 実行前の hash を記録。workspace-write は WORK_TREE 配下に
+# 書込を制限するが (ledger は配下外)、多層防御として hash を検証する。
 LEDGER_HASH_BEFORE="$(shasum "$LEDGER" 2>/dev/null | awk '{print $1}' || echo none)"
+# push 先改ざん検出: workspace-write は git 実行を許すため、codex が WORK_TREE の origin remote を
+# 書き換えると push が攻撃者先に向く。scope guard は porcelain ベースで remote 変更を捕捉できない
+# ため、codex 実行前の origin URL を控え push 直前に不変を検証する。
+ORIGIN_URL_BEFORE="$(git -C "$WORK_TREE" remote get-url origin 2>/dev/null || echo "")"
 # 検証 fail 時のデバッグ素材退避。worktree も tmpfile も trap で消えるため、
 # 退避しないと「何が不正だったか」を再現実行なしに調査できない (2026-06-11 初回実行で実証)
 _save_debug() {
@@ -307,35 +312,42 @@ _save_debug() {
     echo "[learned-promote] debug saved: $dst" >&2
 }
 
-CLAUDE_LOG=$(mktemp -t "lp-claude.XXXXXX"); _TMPFILES+=("$CLAUDE_LOG")
+# 2026-06-14: claude -p → codex workspace-write 移行。
+# codex を -C "$WORK_TREE" --sandbox workspace-write で起動すると、sandbox が編集範囲を
+# 専用 worktree 配下に物理的に制限する (claude の prompt ベース制限より強い)。network は
+# codex 既定で無効。manifest は codex が WORK_TREE 内に書き、後段の多層ガード (manifest 検証 /
+# ledger hash / scope guard / adopted-target-modified) で出力を検証する。
+# 注意: workspace-write は git 実行を許す (claude の --allowedTools 除外より緩い)。prompt で
+# git 禁止を指示しているが、万一 codex が commit してもガードが安全側に倒す (no changes staged
+# fail。bad PR は作られない)。プロンプトは stdin 経由 (positional arg は stdin EOF 待ちで hang)。
+CLAUDE_LOG=$(mktemp -t "lp-codex.XXXXXX"); _TMPFILES+=("$CLAUDE_LOG")
 CLAUDE_ERR=$(mktemp -t "lp-err.XXXXXX"); _TMPFILES+=("$CLAUDE_ERR")
-if ! "$TIMEOUT_BIN" 900s claude -p "$PROMPT" --model "${NIGHTLY_CLAUDE_MODEL:-claude-sonnet-4-6}" \
-        --allowedTools "Read,Edit,Write,Glob,Grep" \
-        --output-format text > "$CLAUDE_LOG" 2> "$CLAUDE_ERR"; then
+if ! printf '%s' "$PROMPT" | "$TIMEOUT_BIN" 900s codex exec \
+        --skip-git-repo-check -m "${NIGHTLY_CODEX_MODEL:-gpt-5.5}" \
+        --sandbox workspace-write -C "$WORK_TREE" \
+        --config model_reasoning_effort="${NIGHTLY_CODEX_EFFORT:-high}" \
+        > "$CLAUDE_LOG" 2> "$CLAUDE_ERR"; then
     release_claude_lock
     _save_debug
-    status_end fail "claude -p failed/timeout(900s): $(head -c 200 "$CLAUDE_ERR" 2>/dev/null)"
+    # codex のエラーは stderr に出る。空なら stdout(trace) 末尾で補う (通知に診断材料を残す)
+    _err="$(head -c 200 "$CLAUDE_ERR" 2>/dev/null)"
+    [[ -z "$_err" ]] && _err="$(tail -c 200 "$CLAUDE_LOG" 2>/dev/null)"
+    status_end fail "codex failed/timeout(900s): $_err"
     exit 0
 fi
 release_claude_lock
 
-if grep -qiE '^[[:space:]]*execution error' "$CLAUDE_LOG" 2>/dev/null; then
-    _save_debug
-    status_end fail "claude -p returned 'Execution error' (exit 0)"
-    exit 0
-fi
-
-# --- ledger 改ざん検出 (claude は ledger を触ってはならない) ---
+# --- ledger 改ざん検出 (codex は ledger を触ってはならない) ---
 LEDGER_HASH_AFTER="$(shasum "$LEDGER" 2>/dev/null | awk '{print $1}' || echo none)"
 if [[ "$LEDGER_HASH_BEFORE" != "$LEDGER_HASH_AFTER" ]]; then
-    status_end fail "claude modified the ledger (forbidden); abort without PR"
+    status_end fail "codex modified the ledger (forbidden); abort without PR"
     exit 0
 fi
 
-# --- manifest 検証 (claude の出力を信頼しない) ---
+# --- manifest 検証 (codex の出力を信頼しない) ---
 if [[ ! -f "$MANIFEST_PATH" ]]; then
     _save_debug
-    status_end fail "claude did not write manifest"
+    status_end fail "codex did not write manifest"
     exit 0
 fi
 if ! jq empty "$MANIFEST_PATH" 2>/dev/null; then
@@ -407,6 +419,12 @@ if ! git -C "$WORK_TREE" commit -m "$COMMIT_MSG" >/dev/null 2>&1; then
     PATCH="${PATCH_DIR}/learned-promote-failed-${RUN_ID}.patch"
     git -C "$WORK_TREE" diff --cached > "$PATCH" 2>/dev/null || PATCH="(patch save failed)"
     status_end fail "git commit failed (pre-commit hook?); patch=$PATCH"
+    exit 0
+fi
+# push 先改ざん検出: codex が origin remote を書き換えていないか push 直前に検証する
+ORIGIN_URL_AFTER="$(git -C "$WORK_TREE" remote get-url origin 2>/dev/null || echo "")"
+if [[ "$ORIGIN_URL_BEFORE" != "$ORIGIN_URL_AFTER" ]]; then
+    status_end fail "origin remote URL changed during codex run (forbidden); abort before push"
     exit 0
 fi
 if ! git -C "$WORK_TREE" push -u origin "$BRANCH" >/dev/null 2>&1; then

--- a/scripts/runtime/nightly/run-skill-audit.sh
+++ b/scripts/runtime/nightly/run-skill-audit.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-# run-skill-audit.sh — skill A/B benchmark + health audit
+# run-skill-audit.sh — skill health audit (静的)
 # cron: 45 23 * * *  (DOW=4 木曜、catch-up 6 days)
-# 既存 /skill-audit skill を claude -p で呼び出す (Q2 反映: exact invocation)
+#
+# 2026-06-14: claude -p "/skill-audit" → codex 移行。
+# /skill-audit skill は Claude 専用機構で codex からは呼べないため、skill が行う
+# 静的 health audit (5D 品質スキャン / trigger 衝突検出 / usage tier / Keep-Improve-Retire 分類)
+# を codex プロンプトとして再実装する。A/B runtime benchmark (Claude eval 実行が必要) は
+# codex では実行不能なため意図的に対象外 (レポート冒頭にその旨を明記させる)。
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,6 +14,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/lib/nightly-status.sh"
 
 TASK="skill-audit"
+DOTFILES_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SKILLS_DIR="${DOTFILES_DIR}/.config/claude/skills"
+SKILL_EXEC_LOG="${HOME}/.claude/agent-memory/learnings/skill-executions.jsonl"
 
 _cleanup() {
     local ec=$?
@@ -23,7 +31,7 @@ if [[ -z "${OBSIDIAN_VAULT_PATH:-}" ]]; then
     status_begin "$TASK"; status_end fail "missing OBSIDIAN_VAULT_PATH"
     exit 0
 fi
-for cmd in jq claude; do
+for cmd in jq codex; do
     if ! command -v "$cmd" &>/dev/null; then
         status_begin "$TASK"; status_end fail "preflight: $cmd CLI not found"
         exit 0
@@ -49,26 +57,73 @@ REPORT_PATH="${REPORT_DIR}/${NIGHTLY_DATE}-skill.md"
 REPORT_TMP=$(mktemp -t "nightly-skill-${NIGHTLY_DATE}.XXXXXX")
 trap 'rm -f "$REPORT_TMP"; _cleanup' EXIT
 
-# Q2 反映: exact "/skill-audit" invocation
-STDERR_LOG=$(mktemp -t "nightly-skill-stderr.XXXXXX")
-if ! "$TIMEOUT_BIN" 900s claude -p "/skill-audit" > "$REPORT_TMP" 2> "$STDERR_LOG"; then
-    err_head=$(head -c 200 "$STDERR_LOG" 2>/dev/null || echo "")
-    rm -f "$STDERR_LOG"
-    status_end fail "claude -p /skill-audit failed/timeout, stderr: $err_head"
+# skill health audit プロンプト (codex 再実装: /skill-audit の静的部分)
+PROMPT="あなたは Claude Code の skill 定義を監査する health auditor です。
+read-only でファイルを読み、Markdown レポートを 1 つ生成してください (ファイル編集は禁止)。
+
+## 対象
+- skill 定義: ${SKILLS_DIR}/*/SKILL.md (各 skill の frontmatter description と本文)
+- 使用ログ: ${SKILL_EXEC_LOG} (JSON-lines。過去30日の skill 実行回数集計に使う。
+  存在しない/データ不足なら usage 判定はスキップし、静的スキャンのみで判定する)
+
+## スコープ (重要)
+A/B runtime benchmark (Claude eval 実行) は codex では実行不能なため**対象外**です。
+本監査は静的 health audit のみ。レポート冒頭にこの旨を 1 行明記してください。
+
+## 監査項目
+1. **5D 品質スキャン**: 各 skill を Safety / Completeness / Executability / Maintainability /
+   Cost-awareness の 5 次元で Good/Average/Poor 判定。いずれか Poor なら Improve 分類。
+2. **trigger 衝突検出**: description の Triggers が重複・曖昧で誤起動を招く skill ペアを検出。
+   検出した各ペアは行頭に必ず 「[CONFLICT]」マーカーを付ける。
+3. **usage tier**: 使用ログから Dominant(40%以上) / Weekly(4回+) / Monthly(1-3回) / Unused(0回) に分類。
+   Unused の skill は Retire Candidates に列挙し、各行頭に必ず 「[DORMANT]」マーカーを付ける。
+4. **Keep / Improve / Retire** に各 skill を分類。
+
+## 出力フォーマット (Markdown)
+重要: [CONFLICT] / [DORMANT] マーカーは該当する finding 行頭にのみ付け、見出しや Summary には付けない
+(スクリプトがマーカー数で件数を集計するため)。
+
+# Skill Audit Report (${NIGHTLY_DATE})
+
+> 注記: A/B runtime benchmark は対象外 (codex 静的監査)。
+
+## Summary
+- 監査 skill 数: N
+- Keep: X / Improve: Y / Retire candidates: Z
+- trigger conflict pairs: C
+
+## Conflicts
+- [CONFLICT] <skillA> vs <skillB> — <理由>
+
+## Retire Candidates
+- [DORMANT] <skill>: 未使用 (0回) — <根拠>
+
+## Improve
+- <skill>: <Poor 次元と改善方向>
+
+## Keep
+- <skill> ...
+
+衝突 0 件・retire 候補 0 件なら各セクションに 'なし' と記載してください
+(マーカー行は出さない)。"
+
+# codex exec (read-only 分析 → -o で REPORT_TMP に最終メッセージのみ書き出す)
+if ! run_codex_report 900 "$REPORT_TMP" "$PROMPT"; then
+    status_end fail "codex failed/timeout: $CODEX_ERR_HEAD"
     exit 0
 fi
-rm -f "$STDERR_LOG"
 
 mv "$REPORT_TMP" "$REPORT_PATH"
 
-DORMANT=$(grep -cE 'dormant|未使用|0 calls' "$REPORT_PATH" 2>/dev/null || true)
-CONFLICTS=$(grep -cE '衝突|conflict' "$REPORT_PATH" 2>/dev/null || true)
+# マーカー数で集計 (見出し/Summary の語句を誤カウントしない)
+DORMANT=$(grep -cF '[DORMANT]' "$REPORT_PATH" 2>/dev/null || true)
+CONFLICTS=$(grep -cF '[CONFLICT]' "$REPORT_PATH" 2>/dev/null || true)
 DORMANT="${DORMANT:-0}"
 CONFLICTS="${CONFLICTS:-0}"
 
 # Discord 詳細: dormant / conflicts 該当行 top 5
 DETAIL="dormant=$DORMANT conflicts=$CONFLICTS"
-TOP_FINDINGS=$(grep -E 'dormant|未使用|0 calls|衝突|conflict' "$REPORT_PATH" 2>/dev/null | head -5 || true)
+TOP_FINDINGS=$(grep -F -e '[DORMANT]' -e '[CONFLICT]' "$REPORT_PATH" 2>/dev/null | head -5 || true)
 [[ -n "$TOP_FINDINGS" ]] && DETAIL+=$'\n\nTop findings:\n'"$TOP_FINDINGS"
 
 status_end ok "dormant=$DORMANT conflicts=$CONFLICTS" \

--- a/scripts/runtime/tech-researcher/run-tech-researcher.sh
+++ b/scripts/runtime/tech-researcher/run-tech-researcher.sh
@@ -58,8 +58,8 @@ for cmd in jq curl python3; do
         exit 0
     fi
 done
-if [[ "${TECH_RESEARCHER_DRY_RUN:-0}" != "1" ]] && ! command -v claude &>/dev/null; then
-    status_begin "$TASK"; status_end fail "preflight: claude CLI not found"
+if [[ "${TECH_RESEARCHER_DRY_RUN:-0}" != "1" ]] && ! command -v codex &>/dev/null; then
+    status_begin "$TASK"; status_end fail "preflight: codex CLI not found"
     exit 0
 fi
 TIMEOUT_BIN=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
@@ -171,26 +171,16 @@ if [[ "${TECH_RESEARCHER_DRY_RUN:-0}" == "1" ]]; then
         echo '```'
     } > "$REPORT_RAW"
 else
-    # nightly batch (audit/skill-audit) と claude -p の同時実行を回避 (5分待ち)。
-    # 収集は lock 不要、claude 呼び出し直前でのみ取得する。
+    # nightly batch (audit/skill-audit) と codex の同時実行を回避 (5分待ち)。
+    # 収集は lock 不要、codex 呼び出し直前でのみ取得する (orchestrator 下では no-op)。
     if ! acquire_claude_lock; then
-        status_end fail "claude lock timeout"
+        status_end fail "codex lock timeout"
         exit 0
     fi
-    # 暴走防止は timeout 600s が hard stop (--tools "" / --max-budget-usd は claude -p で
-    # "Execution error" を誘発し使用不可 — 2026-06-04 実地確認)。-p の純テキスト選別は
-    # 単発応答なのでツール暴走リスクは低く、wall-clock 上限で十分。
-    STDERR_LOG=$(mktemp -t "tr-stderr.XXXXXX"); _TMPFILES+=("$STDERR_LOG")
-    if ! "$TIMEOUT_BIN" 600s claude -p "$PROMPT" --model "${NIGHTLY_CLAUDE_MODEL:-claude-sonnet-4-6}" --output-format text \
-            > "$REPORT_RAW" 2> "$STDERR_LOG"; then
-        err_head=$(head -c 200 "$STDERR_LOG" 2>/dev/null || echo "")
-        status_end fail "claude -p failed/timeout, stderr: $err_head"
-        exit 0
-    fi
-    # claude -p は内部失敗時 exit 0 のまま本文に "Execution error" を出すことがある。
-    # 先頭行を trim + 大小無視で照合 (先頭空白/大小ゆれを誤って成功扱いしない)。
-    if head -n1 "$REPORT_RAW" 2>/dev/null | grep -qiE '^[[:space:]]*execution error'; then
-        status_end fail "claude -p returned 'Execution error' (exit 0)"
+    # 暴走防止は timeout 600s が hard stop。純テキスト選別 (候補リストは PROMPT 埋め込み済) は
+    # 単発応答なので read-only sandbox で十分。-o で最終メッセージのみ REPORT_RAW に書く。
+    if ! run_codex_report 600 "$REPORT_RAW" "$PROMPT"; then
+        status_end fail "codex failed/timeout: $CODEX_ERR_HEAD"
         exit 0
     fi
 fi

--- a/tools/nightly-orchestrator/main.go
+++ b/tools/nightly-orchestrator/main.go
@@ -70,7 +70,8 @@ func run(jobsPath string, dryRun bool) error {
 		"NIGHTLY_NOTIFY_DISABLE": "1",
 		"NIGHTLY_DATE_OVERRIDE":  date,
 		"OBSIDIAN_VAULT_PATH":    os.Getenv("OBSIDIAN_VAULT_PATH"),
-		"NIGHTLY_CLAUDE_MODEL":   envOr("NIGHTLY_CLAUDE_MODEL", "claude-sonnet-4-6"),
+		"NIGHTLY_CODEX_MODEL":    envOr("NIGHTLY_CODEX_MODEL", "gpt-5.5"),
+		"NIGHTLY_CODEX_EFFORT":   envOr("NIGHTLY_CODEX_EFFORT", "high"),
 	}
 
 	o := orchestrator.New(cfg, orchestrator.Options{


### PR DESCRIPTION
## 概要

夜間バッチ (nightly orchestrator) の LLM 呼び出しを `claude -p` から `codex exec` に移行。

**動機**: headless launchd 文脈での `claude -p` が不安定 (Keychain 依存 / default-model 依存 / fable-5 classifier outage で Bash classifier 全死)。`codex exec` は CODEX_HOME 認証で headless 安定。
※ PC 起動問題は `pmset wakepoweron 22:15 daily` で既に解決済み (runtime 非依存)。

## 変更内容 (10ファイル)

| 種別 | 対象 | 変更 |
|---|---|---|
| 共通ヘルパー | `lib/nightly-status.sh` | `run_codex_report()` 追加 (stdin プロンプト + `-o` で最終メッセージのみ出力、reasoning trace 分離。`NIGHTLY_CODEX_MODEL`/`EFFORT` 上書き可) |
| read-only 5本 | golden-check / audit / daily-report / health-check / tech-researcher(選別) | `claude -p` → `run_codex_report`。preflight `claude`→`codex` |
| skill 再実装 | `run-skill-audit.sh` | `/skill-audit` は Claude 専用機構で codex 不可 → 静的 health audit (5D/trigger衝突/usage tier) を codex プロンプトに再実装。`[DORMANT]`/`[CONFLICT]` マーカーで件数集計。A/B runtime benchmark は対象外 |
| 書込タスク | `run-learned-promote.sh` | codex `--sandbox workspace-write -C "$WORK_TREE"` に移行 (artifact 編集が必要)。多層ガード維持 + **push 先 origin URL 改ざんガード新規追加** |
| 配線 | `launchd-install.sh` / `main.go` | env を `NIGHTLY_CODEX_MODEL`/`EFFORT` に変更、plist に `CODEX_HOME` 明示注入 |

## 検証

- ✅ golden-check e2e (helper 経路): クリーンレポート生成・`violations` 抽出確認
- ✅ skill-audit e2e (codex 再実装): 121 skills スキャン・usage ログ反映・marker 集計 (`dormant=98`/`conflicts=10`) が status JSONL と一致
- ✅ bash -n / go build / go test / validate-configs pass
- ✅ code-reviewer + security-reviewer レビュー → 指摘反映 (fail msg / push 先改ざんガード / CODEX_HOME / preflight / marker 集計)
- ⚠️ learned-promote は実行未検証 (実 PR を作るため)。構文 OK + 多層ガードはレビュー済み

## レビュー注記

- Codex Review Gate は code-reviewer + security-reviewer (Sonnet) で代替 (codex-reviewer subagent は CLI 到達不能時に haiku silent fallback で degrade する既知問題のため)。深い検証が要れば `/codex:review` を手動推奨
- 残課題 (follow-up): prompt-injection のデータ境界内インジェクション (nonce sentinel はデータ境界偽造のみ防御) は claude -p 時代からの既存リスク。learned-promote は PR 人間ゲートで bounded、tech-researcher は read-only で bounded

## マージ後の手順

1. master 上で `task nightly:install` (caffeinate + orchestrator 再ビルド + plist 再 load)
2. `launchctl list | grep nightly` で 2 本確認
3. `rm ~/.claude/agent-memory/LOOP_DISABLED` で再開