### PR TITLE
🐛 fix(nightly): codex を絶対パス指定 + config 隔離で launchd login shell でも動かす

### DIFF
--- a/scripts/runtime/nightly/launchd-install.sh
+++ b/scripts/runtime/nightly/launchd-install.sh
@@ -21,6 +21,23 @@ NIGHTLY_CODEX_MODEL="${NIGHTLY_CODEX_MODEL:-gpt-5.5}"
 NIGHTLY_CODEX_EFFORT="${NIGHTLY_CODEX_EFFORT:-high}"
 CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 
+# codex バイナリの絶対パスを install 時 (= operator の対話シェル) に解決して plist env に焼く。
+# launchd の bash -lc (login shell) は .bash_profile 再読込で mise を活性化せず、PATH 解決だと
+# stale な /usr/local/bin/codex 0.39.0 (--output-last-message 短縮形 / remote MCP 非対応) に
+# 落ちて全ジョブ失敗する (2026-06-14 実夜で実証)。絶対パスで PATH 非依存にする。
+NIGHTLY_CODEX_BIN="${NIGHTLY_CODEX_BIN:-$(command -v codex || true)}"
+if [[ -z "$NIGHTLY_CODEX_BIN" || ! -x "$NIGHTLY_CODEX_BIN" ]]; then
+    echo "[ERROR] codex CLI が見つからない (command -v codex)。先に codex を install/activate せよ" >&2
+    exit 1
+fi
+# 解決した codex が --output-last-message を持つか検証 (古い 0.39.0 等を弾く)。
+if ! "$NIGHTLY_CODEX_BIN" exec --help 2>/dev/null | grep -q -- '--output-last-message'; then
+    echo "[ERROR] $NIGHTLY_CODEX_BIN は --output-last-message 非対応 (古すぎ)。codex を更新せよ" >&2
+    "$NIGHTLY_CODEX_BIN" --version >&2 || true
+    exit 1
+fi
+echo "[install] codex bin: $NIGHTLY_CODEX_BIN ($("$NIGHTLY_CODEX_BIN" --version 2>/dev/null))"
+
 # wake/caffeinate 時刻の単一真実源 (setup-nightly-wake.sh の pmset と揃える)
 # shellcheck source=./nightly-wake.env
 source "${NIGHTLY_DIR}/nightly-wake.env"
@@ -83,6 +100,8 @@ generate_plist() {
         <string>${NIGHTLY_CODEX_MODEL}</string>
         <key>NIGHTLY_CODEX_EFFORT</key>
         <string>${NIGHTLY_CODEX_EFFORT}</string>
+        <key>NIGHTLY_CODEX_BIN</key>
+        <string>${NIGHTLY_CODEX_BIN}</string>
     </dict>
     <key>StandardOutPath</key>
     <string>/tmp/nightly-${task}.launchd.log</string>
@@ -135,6 +154,7 @@ generate_orchestrator_plist() {
         <key>OBSIDIAN_VAULT_PATH</key><string>${VAULT_PATH}</string>
         <key>NIGHTLY_CODEX_MODEL</key><string>${NIGHTLY_CODEX_MODEL}</string>
         <key>NIGHTLY_CODEX_EFFORT</key><string>${NIGHTLY_CODEX_EFFORT}</string>
+        <key>NIGHTLY_CODEX_BIN</key><string>${NIGHTLY_CODEX_BIN}</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/runtime/nightly/lib/nightly-status.sh
+++ b/scripts/runtime/nightly/lib/nightly-status.sh
@@ -356,21 +356,31 @@ release_claude_lock() {
 # 理由: launchd 直叩きの claude -p は default model / Keychain 依存で不安定
 # (fable-5 classifier outage 等)。codex exec は CODEX_HOME 認証で headless 安定。
 #
-# 出力分離: codex の stdout は reasoning trace なので、最終メッセージは -o で
-# 専用ファイルに書き出す (claude -p は stdout=本文だったため redirect で取れた)。
-# プロンプトは stdin 経由で渡す (positional arg だと stdin EOF 待ちで hang する —
-# 2026-06-14 実地確認)。
+# 出力分離: codex の stdout は reasoning trace なので、最終メッセージは
+# --output-last-message で専用ファイルに書き出す (claude -p は stdout=本文だったため
+# redirect で取れた)。プロンプトは stdin 経由で渡す (positional arg だと stdin EOF 待ちで
+# hang する — 2026-06-14 実地確認)。
+#
+# codex バイナリは NIGHTLY_CODEX_BIN の絶対パスを使う。launchd の bash -lc (login shell) は
+# .bash_profile 再読込で mise を活性化せず PATH に新しい codex が乗らないため、PATH 解決だと
+# stale な /usr/local/bin/codex 0.39.0 に落ちる (2026-06-14 実夜で実証)。install 時に
+# command -v codex で解決した絶対パスを plist env 経由で渡す。
+#
+# --ignore-user-config: 無人バッチを ~/.codex/config.toml の drift から隔離する (remote MCP
+# サーバ等が壊れると codex 起動ごと失敗するため)。auth は CODEX_HOME から読むので維持される。
 #
 # モデル/推論強度は env で上書き可:
 #   NIGHTLY_CODEX_MODEL  (既定 gpt-5.5)
 #   NIGHTLY_CODEX_EFFORT (既定 high — golden パイロットで検証済)
+#   NIGHTLY_CODEX_BIN    (既定 codex — install 時に絶対パスへ解決)
 # ============================================================
 NIGHTLY_CODEX_MODEL="${NIGHTLY_CODEX_MODEL:-gpt-5.5}"
 NIGHTLY_CODEX_EFFORT="${NIGHTLY_CODEX_EFFORT:-high}"
+NIGHTLY_CODEX_BIN="${NIGHTLY_CODEX_BIN:-codex}"
 
 # run_codex_report — read-only 分析 → レポート生成の共通ラッパー (claude -p 置換)。
 # Usage: run_codex_report <timeout_sec> <out_file> <prompt>
-#   最終メッセージを -o で <out_file> に書く。codex の trace は捨てる。
+#   最終メッセージを --output-last-message で <out_file> に書く。codex の trace は捨てる。
 # 戻り値: 成功 0 / 失敗 非0。失敗時はグローバル CODEX_ERR_HEAD に trace 先頭 200B。
 # timeout は TIMEOUT_BIN (呼び出し側 preflight で解決済) を使う。未解決なら自前で探す。
 CODEX_ERR_HEAD=""
@@ -384,10 +394,10 @@ run_codex_report() {
     fi
     local trace
     trace=$(mktemp -t "nightly-codex-trace.XXXXXX")
-    if ! printf '%s' "$prompt" | "$tbin" "${timeout_sec}s" codex exec \
+    if ! printf '%s' "$prompt" | "$tbin" "${timeout_sec}s" "$NIGHTLY_CODEX_BIN" exec \
             --skip-git-repo-check -m "$NIGHTLY_CODEX_MODEL" --sandbox read-only \
-            --config model_reasoning_effort="$NIGHTLY_CODEX_EFFORT" \
-            -o "$out_file" > "$trace" 2>&1; then
+            --ignore-user-config --config model_reasoning_effort="$NIGHTLY_CODEX_EFFORT" \
+            --output-last-message "$out_file" > "$trace" 2>&1; then
         CODEX_ERR_HEAD=$(head -c 200 "$trace" 2>/dev/null || echo "")
         rm -f "$trace"
         return 1

--- a/scripts/runtime/nightly/run-learned-promote.sh
+++ b/scripts/runtime/nightly/run-learned-promote.sh
@@ -322,9 +322,9 @@ _save_debug() {
 # fail。bad PR は作られない)。プロンプトは stdin 経由 (positional arg は stdin EOF 待ちで hang)。
 CLAUDE_LOG=$(mktemp -t "lp-codex.XXXXXX"); _TMPFILES+=("$CLAUDE_LOG")
 CLAUDE_ERR=$(mktemp -t "lp-err.XXXXXX"); _TMPFILES+=("$CLAUDE_ERR")
-if ! printf '%s' "$PROMPT" | "$TIMEOUT_BIN" 900s codex exec \
+if ! printf '%s' "$PROMPT" | "$TIMEOUT_BIN" 900s "${NIGHTLY_CODEX_BIN:-codex}" exec \
         --skip-git-repo-check -m "${NIGHTLY_CODEX_MODEL:-gpt-5.5}" \
-        --sandbox workspace-write -C "$WORK_TREE" \
+        --sandbox workspace-write -C "$WORK_TREE" --ignore-user-config \
         --config model_reasoning_effort="${NIGHTLY_CODEX_EFFORT:-high}" \
         > "$CLAUDE_LOG" 2> "$CLAUDE_ERR"; then
     release_claude_lock

--- a/tools/nightly-orchestrator/main.go
+++ b/tools/nightly-orchestrator/main.go
@@ -72,6 +72,7 @@ func run(jobsPath string, dryRun bool) error {
 		"OBSIDIAN_VAULT_PATH":    os.Getenv("OBSIDIAN_VAULT_PATH"),
 		"NIGHTLY_CODEX_MODEL":    envOr("NIGHTLY_CODEX_MODEL", "gpt-5.5"),
 		"NIGHTLY_CODEX_EFFORT":   envOr("NIGHTLY_CODEX_EFFORT", "high"),
+		"NIGHTLY_CODEX_BIN":      envOr("NIGHTLY_CODEX_BIN", "codex"),
 	}
 
 	o := orchestrator.New(cfg, orchestrator.Options{


### PR DESCRIPTION
## 概要

#91 (claude -p → codex 移行) を**実夜実走行 (launchctl kickstart)** したところ全 codex ジョブが失敗。原因は **Plus quota ではなく環境バグ2つ**。実走行でのみ捕捉できた。

## 真因 (実証済み)

| バグ | 内容 |
|---|---|
| **codex バージョン不一致** | launchd の `bash -lc` (login shell) は `.bash_profile` 再読込で mise を活性化せず、PATH 解決だと stale な `/usr/local/bin/codex 0.39.0` に落ちる。0.39.0 は `--output-last-message` 短縮形 `-o` 非対応 + `~/.codex/config.toml` の remote MCP (`openaiDeveloperDocs`) 解析不可 → 全ジョブ失敗。対話/隔離テストは mise 0.137.0 を使うため通り、見逃した |

## 修正 (4ファイル)

1. **`lib/nightly-status.sh`**: `run_codex_report` が `${NIGHTLY_CODEX_BIN:-codex}` (絶対パス) を使用、`-o` → `--output-last-message` (長形・版間移植性)、`--ignore-user-config` 追加 (config.toml drift から無人バッチを隔離、auth は CODEX_HOME 維持)
2. **`run-learned-promote.sh`**: 同様に `${NIGHTLY_CODEX_BIN:-codex}` + `--ignore-user-config`
3. **`launchd-install.sh`**: install 時に `command -v codex` で絶対パス解決 + `--output-last-message` 対応を検証 (古い版を fail-fast で弾く) + 両 plist の env に `NIGHTLY_CODEX_BIN` 注入
4. **`main.go`**: orchestrator commonEnv に `NIGHTLY_CODEX_BIN` 伝播

env 伝播経路: install 時解決 → plist EnvironmentVariables → orchestrator os.Environ/commonEnv → child `bash -lc` (`${NIGHTLY_CODEX_BIN}`)

## 検証

- ✅ **失敗していた env を正確に再現** (`/bin/bash -lc` login shell + launchd PATH で bare codex=0.39.0 + `NIGHTLY_CODEX_BIN`=mise 0.137.0) → golden-check **ok** (violations=7、クリーン 3.8K レポート、147s)
- ✅ bash -n / go build / go vet pass
- ✅ code-reviewer PASS (security 5/5、CONSIDER 2件は次PR可)

## レビュー注記
- 実走行で判明した plan-close-scan 失敗は `doc-status-audit.py` の `X | None` 型注釈が古い Python で動かない**既存バグ (本PRと無関係)**。別途要対応