### PR TITLE
🔧 fix(nightly): learned-promote 絵文字 + doc-status-audit を Python 3.9 互換化 (残2 fail 解消)

### DIFF
--- a/scripts/lifecycle/doc-status-audit.py
+++ b/scripts/lifecycle/doc-status-audit.py
@@ -26,6 +26,8 @@ Output:
   - JSONL: ~/.claude/logs/doc-status-audit-{date}.jsonl
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import re

--- a/scripts/runtime/nightly/run-learned-promote.sh
+++ b/scripts/runtime/nightly/run-learned-promote.sh
@@ -408,7 +408,7 @@ if [[ -n "$MISSING_TARGET" ]]; then
     status_end fail "adopted target not actually modified: $MISSING_TARGET"
     exit 0
 fi
-COMMIT_MSG="🌱 chore(learned): 昇格候補 ${SLICE_COUNT} 件 (adopted=${ADOPTED} rejected=${REJECTED})
+COMMIT_MSG="🔧 chore(learned): 昇格候補 ${SLICE_COUNT} 件 (adopted=${ADOPTED} rejected=${REJECTED})
 
 learned-promote nightly が ${RUN_ID} の昇格候補を非対話 promote。
 ledger 反映はこの PR のマージ後 reconcile で行う (merge-coupled)。
@@ -476,7 +476,7 @@ $(cat "$MANIFEST_PATH")
 
 if ! PR_URL="$(gh pr create --repo "$GH_REPO" \
         --base master --head "$BRANCH" \
-        --title "🌱 learned 昇格 ${RUN_ID} (adopted=${ADOPTED} rejected=${REJECTED})" \
+        --title "🔧 learned 昇格 ${RUN_ID} (adopted=${ADOPTED} rejected=${REJECTED})" \
         --body "$PR_BODY" 2>&1)"; then
     # push 済みなのでリモートブランチを掃除 (orphan 防止)。ローカルは trap が削除。
     git -C "$WORK_TREE" push origin ":$BRANCH" >/dev/null 2>&1 || true


### PR DESCRIPTION
## 概要

#91/#93 後の **実走行 (launchctl kickstart)** で残った 2 ジョブの fail を解消し nightly を完全グリーンにする。どちらも codex/quota とは無関係の既存バグ。

## 修正

| ジョブ | 真因 | 修正 |
|---|---|---|
| **learned-promote** | COMMIT_MSG/PR title の `🌱` が lefthook `conventional-commit` の許可絵文字外 → commit-msg hook が拒否。codex 部分は成功していたが commit 段階で落ちていた (既存バグ、codex が commit に到達して露出) | `🌱` → `🔧` (chore) |
| **plan-close-scan** | `doc-status-audit.py` の `dict[str,str] \| None` (PEP 604) を launchd の system Python **3.9.6** が実行時 TypeError。importlib で読まれるため import ごと失敗 | `from __future__ import annotations` 追加 (注釈を遅延文字列化) |

両者は **「launchd の bash -lc が mise でなく古い system ツール (codex 0.39 / Python 3.9) を使う」** 族の問題 (#93 の codex バージョン問題と同根)。

## 検証 (失敗環境を再現)

- ✅ `🔧 chore(learned): ...` が conventional-commit hook を通過 (repro commit 成功)
- ✅ `doc-status-audit.py` が system Python 3.9.6 で import OK (TypeError 解消)
- ✅ `run-plan-close-scan.sh` を `/bin/bash -lc` + launchd PATH + system Python で e2e → **status=ok** (18s)
- ✅ code-reviewer PASS (5/5、指摘なし)

## マージ後

- **再 install 不要** (orchestrator binary 不変。scripts は実行時に master から読まれる)
- learned-promote のフル経路 (codex 編集 → 🔧 commit → push → PR) は次の DOW=7 (日曜) で初稼働。今すぐ確認したい場合は `FORCE_RUN=1 LEARNED_PROMOTE_DOW=$(date +%u) bash scripts/runtime/nightly/run-learned-promote.sh` (実 PR を作る点に注意)