### PR TITLE
🔧 chore(settings): effortLevel high→xhigh に同期

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -914,7 +914,7 @@
       ]
     }
   },
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "outputStyle": "prose",
   "plansDirectory": "./tmp/plans",
   "skipWorkflowUsageWarning": true,


### PR DESCRIPTION
## Summary
- `/effort` で設定済みの `effortLevel: xhigh` を settings.json に commit。
- 目的: main worktree に浮いていた未コミット差分 (pull / stash で繰り返し friction を発生させていた) を解消し、committed の default に揃える。

## Test plan
- [x] settings.json JSON valid
- [x] outputStyle: prose (#97) と共存、他フィールド非変更