### PR TITLE
🔧 learned 昇格 20260615-222309 (adopted=2 rejected=3)

### DIFF
--- a/.config/claude/references/managed-agents-scheduling.md
+++ b/.config/claude/references/managed-agents-scheduling.md
@@ -14,6 +14,7 @@ last_reviewed: 2026-05-14
 | AutoEvolve | cron | 毎日 03:00 | `scripts/runtime/autoevolve-runner.sh` |
 
 launchd plist から `bash -lc <script-path>` 形式で起動するスクリプトは、事前に `+x` を確認する。shell がパスを直接 exec するため、実行権限がないと `exit 126 Permission denied` で失敗する。
+Python スクリプトを同経路で動かす場合、`python3` が macOS system Python 3.9 に解決されることがある。nightly / launchd 対象の Python は `from __future__ import annotations` を先頭に置き、PEP 604 形式の注釈 (`X | None`) が実行時評価で `TypeError` にならないようにする。
 
 ## Managed Agents API での代替
 

--- a/.config/claude/skills/research/SKILL.md
+++ b/.config/claude/skills/research/SKILL.md
@@ -262,6 +262,7 @@ wait
 ### フォールバック
 
 モデルがエラーや空出力を返した場合、claude -p で同じプロンプトを再実行する。
+Gemini が wide web search / critique 系サブタスクで長時間後に空出力を返した場合は、Gemini subagent を再試行せず、失敗を記録して Codex-only の批評に切り替える。
 
 ### ディレクトリ構造
 

--- a/docs/learned-promote/20260615-222309.json
+++ b/docs/learned-promote/20260615-222309.json
@@ -1,0 +1,42 @@
+{
+  "date": "2026-06-15",
+  "branch": "auto/learned-promote-20260615-222309",
+  "max": 5,
+  "promotions": [
+    {
+      "key": "03edb938ee1b366546c7673444998d904f28d694",
+      "decision": "rejected",
+      "scope": "skill-nesting",
+      "reason": "already covered: .config/claude/skills/absorb/SKILL.md",
+      "detail_excerpt": "subagent からの skill ネスト呼び出しは timeout する"
+    },
+    {
+      "key": "d1ea903b95461e5f88a91bbf5d64a023841201fd",
+      "decision": "adopted",
+      "scope": "gemini-parallel",
+      "target_artifact": ".config/claude/skills/research/SKILL.md",
+      "detail_excerpt": "Gemini wide web search 空出力時は Codex-only に fallback"
+    },
+    {
+      "key": "484158397c0ab9ef524750cbe0f4ecfc222fb9ed",
+      "decision": "adopted",
+      "scope": "launchd-python",
+      "target_artifact": ".config/claude/references/managed-agents-scheduling.md",
+      "detail_excerpt": "launchd の Python 3.9 では future annotations 必須"
+    },
+    {
+      "key": "a4168b6f88d22102091c90c840674248c668adde",
+      "decision": "rejected",
+      "scope": "rust-python-compat",
+      "reason": "already covered: .config/claude/scripts/lib/session_events.py",
+      "detail_excerpt": "Rust の data ラップを Python 側でフラット化する"
+    },
+    {
+      "key": "d356ca7331c5a69d5a3db698292e54465f7a4f20",
+      "decision": "rejected",
+      "scope": "codex",
+      "reason": "already covered: .config/claude/skills/debate/SKILL.md",
+      "detail_excerpt": "clean context で独立したセカンドオピニオンを得る"
+    }
+  ]
+}


### PR DESCRIPTION
## learned 昇格 (自動生成・人間ゲート = この PR)

nightly `run-learned-promote.sh` が 20260615-222309 の昇格候補 5 件を非対話 promote しました。

- **adopted**: 2 件 (artifact へ追記)
- **rejected**: 3 件 (already covered 等)

### レビュー観点
- 各 artifact 編集が知見を正しく・簡潔に反映しているか
- 同一 scope への偏り (echo chamber) がないか
- 誤爆 (既存と重複) を adopted にしていないか

### Calibration 裁定 (レビューしながら 1 行コピペ・任意)
各候補の自動判断 (adopted/rejected) に同意なら該当行をそのまま実行、不同意なら `--verdict disagree` に変えて実行:

```bash
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key '03edb938ee1b366546c7673444998d904f28d694' --scope 'skill-nesting' --auto 'rejected' --verdict agree --report '20260615-222309'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'd1ea903b95461e5f88a91bbf5d64a023841201fd' --scope 'gemini-parallel' --auto 'adopted' --verdict agree --report '20260615-222309'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key '484158397c0ab9ef524750cbe0f4ecfc222fb9ed' --scope 'launchd-python' --auto 'adopted' --verdict agree --report '20260615-222309'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'a4168b6f88d22102091c90c840674248c668adde' --scope 'rust-python-compat' --auto 'rejected' --verdict agree --report '20260615-222309'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'd356ca7331c5a69d5a3db698292e54465f7a4f20' --scope 'codex' --auto 'rejected' --verdict agree --report '20260615-222309'
```

裁定は `triage-calibration.jsonl` に蓄積され、`calibration-verdict-logger.py stats` で
agreement rate (判断 frontier 指標) を集計できます。

### マージ後
manifest (`docs/learned-promote/20260615-222309.json`) が master に入ると、次回 nightly の
reconcile が processed key を promoted-ledger に記録し、再提案されなくなります。
**却下する場合はこの PR を close** してください (key は ledger に入らず、後で再提案されます)。

<details><summary>manifest</summary>

```json
{
  "date": "2026-06-15",
  "branch": "auto/learned-promote-20260615-222309",
  "max": 5,
  "promotions": [
    {
      "key": "03edb938ee1b366546c7673444998d904f28d694",
      "decision": "rejected",
      "scope": "skill-nesting",
      "reason": "already covered: .config/claude/skills/absorb/SKILL.md",
      "detail_excerpt": "subagent からの skill ネスト呼び出しは timeout する"
    },
    {
      "key": "d1ea903b95461e5f88a91bbf5d64a023841201fd",
      "decision": "adopted",
      "scope": "gemini-parallel",
      "target_artifact": ".config/claude/skills/research/SKILL.md",
      "detail_excerpt": "Gemini wide web search 空出力時は Codex-only に fallback"
    },
    {
      "key": "484158397c0ab9ef524750cbe0f4ecfc222fb9ed",
      "decision": "adopted",
      "scope": "launchd-python",
      "target_artifact": ".config/claude/references/managed-agents-scheduling.md",
      "detail_excerpt": "launchd の Python 3.9 では future annotations 必須"
    },
    {
      "key": "a4168b6f88d22102091c90c840674248c668adde",
      "decision": "rejected",
      "scope": "rust-python-compat",
      "reason": "already covered: .config/claude/scripts/lib/session_events.py",
      "detail_excerpt": "Rust の data ラップを Python 側でフラット化する"
    },
    {
      "key": "d356ca7331c5a69d5a3db698292e54465f7a4f20",
      "decision": "rejected",
      "scope": "codex",
      "reason": "already covered: .config/claude/skills/debate/SKILL.md",
      "detail_excerpt": "clean context で独立したセカンドオピニオンを得る"
    }
  ]
}
```
</details>