### PR TITLE
✨ feat(plugins): ponytail プラグインを追加

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -871,7 +871,8 @@
     "obsidian@obsidian-skills": true,
     "terraform-skill@antonbabenko-terraform": true,
     "warp@claude-code-warp": true,
-    "mattpocock-skills@mattpocock-skills": true
+    "mattpocock-skills@mattpocock-skills": true,
+    "ponytail@ponytail": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {
@@ -903,8 +904,15 @@
         "source": "directory",
         "path": "/Users/takeuchishougo/dotfiles/.config/claude/marketplaces/mattpocock-skills"
       }
+    },
+    "ponytail": {
+      "source": {
+        "source": "github",
+        "repo": "DietrichGebert/ponytail"
+      }
     }
   },
+  "outputStyle": "prose",
   "language": "japanese",
   "sandbox": {
     "filesystem": {
@@ -915,7 +923,6 @@
     }
   },
   "effortLevel": "xhigh",
-  "outputStyle": "prose",
   "plansDirectory": "./tmp/plans",
   "skipWorkflowUsageWarning": true,
   "theme": "light-daltonized",


### PR DESCRIPTION
## Summary
- ponytail プラグイン (`DietrichGebert/ponytail`) を `enabledPlugins` で有効化し、`extraKnownMarketplaces` に marketplace を登録
- スコープを ponytail 単体に限定。`/review` で露出した余分な 3 marketplace は除外:
  - `claude-plugins-official` / `claude-code-plugins` — 定義なしで動く**ビルトイン**のため明示定義は冗長
  - `antonbabenko` — 既存 `antonbabenko-terraform`（同 repo）の重複で参照プラグインゼロ
- `outputStyle` の位置移動を含む（機能的 no-op、容認済み）

## Review notes
- ⚠️ ponytail は third-party の `SessionStart` / `UserPromptSubmit` lifecycle hook を毎セッション実行する（typosquat ではなく MIT・★13.9k の実在 repo だが、third-party コード実行を承知の上で採用）

## Test plan
- [x] JSON 妥当性チェック PASS
- [x] `task validate-configs` PASS
- [x] `task validate-symlinks` PASS
- [ ] 次セッションで ponytail プラグインがロードされることを確認