### PR TITLE
🔧 chore(mise): notebooklm-py を mise pipx backend で宣言管理に追加

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -16,6 +16,10 @@ go = "1.25"       # 野良 brew が amd64(Rosetta) だった → mise で arm64 
 python = "3.13"   # brew 実体 3.14 / 旧 .tool-versions 3.12 から安定版 3.13 に集約
 uv = "latest"     # Nix home.packages から移管 (Intel brew の /usr/local/bin/uv 二重管理を解消)
 
+# NotebookLM CLI (非公式・更新頻繁) — 動画/記事→notebook→分析→fulltext を CLI 化。
+# extras="browser" で playwright 同梱 (chromium は初回 login 時に DL)。認証は `notebooklm login`。
+"pipx:notebooklm-py" = { version = "latest", extras = "browser" }
+
 # rust は当面 rustup (~/.cargo) 維持 — mise の rust backend は rustup を内部利用するため
 # 共存が複雑。シンプルさ優先で現状維持。mise に寄せたくなったら rust = "1.85" を追加。
 


### PR DESCRIPTION
intent(mise): NotebookLM CLI 連携(動画→notebook→分析→fulltext)を別PCでも再現可能にする
decision(notebooklm): uv tool 手動install から mise [tools] 宣言へ移管し二重管理を解消
learned(mise-pipx): extras は inline "pipx:pkg[extra]" だと黙って落ちる。options table { extras = "browser" } が正しい