### PR TITLE
🔧 learned 昇格 20260621-154220 (adopted=0 rejected=5)

### DIFF
--- a/docs/learned-promote/20260621-154220.json
+++ b/docs/learned-promote/20260621-154220.json
@@ -1,0 +1,42 @@
+{
+  "date": "2026-06-21",
+  "branch": "auto/learned-promote-20260621-154220",
+  "max": 5,
+  "promotions": [
+    {
+      "key": "dbfc71ee80a87d18051e4292d51fdda7a5f68a70",
+      "decision": "rejected",
+      "scope": "design-skill-routing-unsurfaced",
+      "reason": "already covered: .config/claude/CLAUDE.md",
+      "detail_excerpt": "design-skill-routing は CLAUDE.md に配線済み"
+    },
+    {
+      "key": "3c24956818d55f70092d5b93edb1d3f71f2eee6f",
+      "decision": "rejected",
+      "scope": "multi-model",
+      "reason": "already covered: .config/claude/skills/review/SKILL.md",
+      "detail_excerpt": "claude-octopus 3-way review は review skill に明記済み"
+    },
+    {
+      "key": "122d9f5016dbdab181714432002eb9ba463441be",
+      "decision": "rejected",
+      "scope": "tocs-paper",
+      "reason": "already covered: .config/claude/references/workflow-guide.md",
+      "detail_excerpt": "config 優先 3x と依存理解 +14 F1 は記載済み"
+    },
+    {
+      "key": "70d74cf4243c84ece8990d7815baa4f45596c99f",
+      "decision": "rejected",
+      "scope": "docker-safety",
+      "reason": "already covered: .config/claude/scripts/policy/docker-safety.py",
+      "detail_excerpt": "multiline docker 検出の re.DOTALL は実装済み"
+    },
+    {
+      "key": "fb0b43b64538b3f051dfefd602ca5bb449d135c0",
+      "decision": "rejected",
+      "scope": "cross-domain-mapper",
+      "reason": "already covered: .config/claude/scripts/lib/storage.py",
+      "detail_excerpt": "HOME 未設定時の Path.home() fallback は実装済み"
+    }
+  ]
+}


### PR DESCRIPTION
## learned 昇格 (自動生成・人間ゲート = この PR)

nightly `run-learned-promote.sh` が 20260621-154220 の昇格候補 5 件を非対話 promote しました。

- **adopted**: 0 件 (artifact へ追記)
- **rejected**: 5 件 (already covered 等)

### レビュー観点
- 各 artifact 編集が知見を正しく・簡潔に反映しているか
- 同一 scope への偏り (echo chamber) がないか
- 誤爆 (既存と重複) を adopted にしていないか

### Calibration 裁定 (レビューしながら 1 行コピペ・任意)
各候補の自動判断 (adopted/rejected) に同意なら該当行をそのまま実行、不同意なら `--verdict disagree` に変えて実行:

```bash
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'dbfc71ee80a87d18051e4292d51fdda7a5f68a70' --scope 'design-skill-routing-unsurfaced' --auto 'rejected' --verdict agree --report '20260621-154220'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key '3c24956818d55f70092d5b93edb1d3f71f2eee6f' --scope 'multi-model' --auto 'rejected' --verdict agree --report '20260621-154220'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key '122d9f5016dbdab181714432002eb9ba463441be' --scope 'tocs-paper' --auto 'rejected' --verdict agree --report '20260621-154220'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key '70d74cf4243c84ece8990d7815baa4f45596c99f' --scope 'docker-safety' --auto 'rejected' --verdict agree --report '20260621-154220'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'fb0b43b64538b3f051dfefd602ca5bb449d135c0' --scope 'cross-domain-mapper' --auto 'rejected' --verdict agree --report '20260621-154220'
```

裁定は `triage-calibration.jsonl` に蓄積され、`calibration-verdict-logger.py stats` で
agreement rate (判断 frontier 指標) を集計できます。

### マージ後
manifest (`docs/learned-promote/20260621-154220.json`) が master に入ると、次回 nightly の
reconcile が processed key を promoted-ledger に記録し、再提案されなくなります。
**却下する場合はこの PR を close** してください (key は ledger に入らず、後で再提案されます)。

<details><summary>manifest</summary>

```json
{
  "date": "2026-06-21",
  "branch": "auto/learned-promote-20260621-154220",
  "max": 5,
  "promotions": [
    {
      "key": "dbfc71ee80a87d18051e4292d51fdda7a5f68a70",
      "decision": "rejected",
      "scope": "design-skill-routing-unsurfaced",
      "reason": "already covered: .config/claude/CLAUDE.md",
      "detail_excerpt": "design-skill-routing は CLAUDE.md に配線済み"
    },
    {
      "key": "3c24956818d55f70092d5b93edb1d3f71f2eee6f",
      "decision": "rejected",
      "scope": "multi-model",
      "reason": "already covered: .config/claude/skills/review/SKILL.md",
      "detail_excerpt": "claude-octopus 3-way review は review skill に明記済み"
    },
    {
      "key": "122d9f5016dbdab181714432002eb9ba463441be",
      "decision": "rejected",
      "scope": "tocs-paper",
      "reason": "already covered: .config/claude/references/workflow-guide.md",
      "detail_excerpt": "config 優先 3x と依存理解 +14 F1 は記載済み"
    },
    {
      "key": "70d74cf4243c84ece8990d7815baa4f45596c99f",
      "decision": "rejected",
      "scope": "docker-safety",
      "reason": "already covered: .config/claude/scripts/policy/docker-safety.py",
      "detail_excerpt": "multiline docker 検出の re.DOTALL は実装済み"
    },
    {
      "key": "fb0b43b64538b3f051dfefd602ca5bb449d135c0",
      "decision": "rejected",
      "scope": "cross-domain-mapper",
      "reason": "already covered: .config/claude/scripts/lib/storage.py",
      "detail_excerpt": "HOME 未設定時の Path.home() fallback は実装済み"
    }
  ]
}
```
</details>