### PR TITLE
🔧 chore(settings): unpin model + enable claude-code-setup plugin

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,16 @@
 {
-	"includeCoAuthoredBy": false,
-	"enableAllProjectMcpServers": true,
-	"enabledMcpjsonServers": ["playwright", "context7"],
-	"permissions": {
-		"allow": ["mcp__plugin_discord_discord__reply"]
-	}
+  "includeCoAuthoredBy": false,
+  "permissions": {
+    "allow": [
+      "mcp__plugin_discord_discord__reply"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "playwright",
+    "context7"
+  ],
+  "enabledPlugins": {
+    "claude-code-setup@claude-plugins-official": true
+  }
 }

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -195,7 +195,6 @@
     ],
     "disableBypassPermissionsMode": "disable"
   },
-  "model": "claude-opus-4-7[1m]",
   "enableAllProjectMcpServers": false,
   "enabledMcpjsonServers": [
     "context7",


### PR DESCRIPTION
## Summary

並列セッション (`claude --teammate-mode tmux` 多数) が master の working tree に残した 2 settings 変更を /review PASS の上で回収・コミット。

## Changes

| File | Change | Rationale |
|---|---|---|
| `.config/claude/settings.json` | `"model": "claude-opus-4-7[1m]"` を削除 (1 行) | CLI/UI 側の `/model` 選択に支配を委ねる方針 (pinned model unpin) |
| `.claude/settings.local.json` | format を 2-space + multi-line array に統一 + `enabledPlugins: {claude-code-setup@claude-plugins-official: true}` 追加 | 既存 settings.json と format 揃え、信頼済 marketplace の setup plugin を 1 件 enable |

## Review

`/review` で PASS (Critical 0 / Important 1 / Watch 1)。

- **Impact Scope** ✅: model unpin + plugin 1 件 enable のみ
- **Style Consistency** ✅: 2-space format は既存 settings.json と整合
- **Security** ✅: claude-plugins-official は信頼 marketplace (`project_claude_builtin_marketplaces.md`)
- **Spec Compliance** ⚠️: spec file なし、意図確認は本 PR description で代用

harness review gate を `harness_review_flag.py write` で解除済。

## Test plan

- [ ] 次セッション起動時に default model が期待通り (Opus 4.7 か Fable 5) か `/model` で確認
- [ ] `claude-code-setup@claude-plugins-official` plugin が起動時 load され skill/hook 追加に副作用ないか確認
- [ ] `task validate-configs` で settings.json schema パス
