### PR TITLE
✨ feat(nix): add crit review CLI + wire agent_cmd to Claude Code

### DIFF
--- a/.crit.config.json
+++ b/.crit.config.json
@@ -1,0 +1,3 @@
+{
+  "agent_cmd": "claude --allowedTools Edit,Read,Bash,Write,Glob,Grep -p"
+}

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -6,6 +6,7 @@ let
 
   # nixpkgs 未収載の自前パッケージ。Go 1.26 必須 (buildGo126Module)。
   ghqr = pkgs.callPackage ../pkgs/ghqr.nix {};
+  crit = pkgs.callPackage ../pkgs/crit.nix {};
 in
 {
   home.username = userName;
@@ -44,6 +45,8 @@ in
     zoxide
     # 自前 derivation: GitHub 設定の best-practices 監査 CLI (microsoft/ghqr)
     ghqr
+    # 自前 derivation: AI エージェント出力のレビュー CLI (tomasz-tomczyk/crit)
+    crit
   ];
 
   # Phase B2.1: symlink.sh の block 1-5 を home-manager に移植 (D6 実証済み)。
@@ -104,6 +107,7 @@ in
     # B2.0 whitelist 翻訳表 (docs/plans/active/2026-04-25-phase-b2-whitelist.md) に基づく。
 
     # Top-level dotfiles (5)
+    ".crit.config.json" = outLink ".crit.config.json";  # crit global config (agent_cmd: Send to agent → Claude Code)
     ".cursorignore"     = outLink ".cursorignore";
     ".tmux.conf"        = outLink ".tmux.conf";
     ".worktreeinclude"  = outLink ".worktreeinclude";

--- a/nix/pkgs/crit.nix
+++ b/nix/pkgs/crit.nix
@@ -1,0 +1,38 @@
+# crit (tomasz-tomczyk/crit) — AI エージェント出力 (plan.md / git diff / ローカル Web) に
+# インラインコメントを付けてエージェントへ送り返すローカルレビュー CLI。
+# nixpkgs 未収載のため自前 derivation。Go 1.26 必須 (upstream go.mod 指定)。
+# レシピは upstream flake.nix を踏襲 (subPackages/doCheck/ldflags)。
+{ lib, buildGo126Module, fetchFromGitHub }:
+
+buildGo126Module rec {
+  pname = "crit";
+  version = "0.16.4";
+
+  src = fetchFromGitHub {
+    owner = "tomasz-tomczyk";
+    repo = "crit";
+    rev = "v${version}";
+    hash = "sha256-1FYrI+IG829TNHGu7+xgr+15EqCZGFUKrL/WCrZ14I0=";
+  };
+
+  vendorHash = "sha256-Y/0K+tVkaYVvyKk0EYzomKc4BwHMMrc9vcDkxpCq/N8=";
+
+  subPackages = [ "cmd/crit" ];
+
+  # Nix sandbox の /build TMPDIR cleanup が debounced review file writer と race する
+  # ため upstream は CI 専用ジョブでテスト、Nix ビルドでは doCheck=false。
+  doCheck = false;
+
+  ldflags = [
+    "-s" "-w"
+    "-X main.version=${version}"
+  ];
+
+  meta = with lib; {
+    description = "Browser-based markdown review tool with inline commenting for AI agent output";
+    homepage = "https://github.com/tomasz-tomczyk/crit";
+    license = licenses.mit;
+    mainProgram = "crit";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## 概要

[crit](https://github.com/tomasz-tomczyk/crit) (tomasz-tomczyk/crit) を導入する。AI エージェント出力 (plan.md / git diff / ローカル Web アプリ / 静的 HTML) にブラウザ上でインラインコメントを付け、フィードバックをエージェントに送り返すローカルレビュー CLI。

## 変更

- **`nix/pkgs/crit.nix`** (新規) — `ghqr` と同じ自前 derivation (`buildGo126Module`)。nixpkgs 未収載のため。upstream flake のレシピを踏襲 (`subPackages=["cmd/crit"]` / `doCheck=false` / `ldflags`)、released 最新タグ **v0.16.4** に pin。
- **`nix/home/default.nix`** — `crit` を `callPackage` + `home.packages` に追加。`~/.crit.config.json` を `outLink` で配線。
- **`.crit.config.json`** (新規) — global config。`agent_cmd` に Claude Code を接続 (`claude --allowedTools Edit,Read,Bash,Write,Glob,Grep -p`、中間権限)。

## 設計判断

- **nix derivation** を選択 (Brewfile は CLI から撤退済みのため不使用)。
- バージョンは **released v0.16.4** に pin (upstream flake は未リリースの 0.16.5 を指すため、そこは released に合わせた)。
- `agent_cmd` は **allowedTools 中間権限**を採用。`--dangerously-skip-permissions` は信頼境界優先で見送り (JSON 1行で変更可)。`agent_cmd` は仕様上 global `~/.crit.config.json` 専用 (悪意ある repo の任意コマンド実行を防ぐ)。

## 検証

- `crit.nix` を nixpkgs-unstable でビルド → 成功、`crit 0.16.4` 起動確認。
- vendorHash は v0.16.4 でも一致 (依存不変)。
- `nix-instantiate --parse` で両 nix ファイルの構文 OK。

## デプロイ手順 (マージ後)

`nh darwin switch ./nix` で `~/.crit.config.json` シンボリックリンク生成 + `crit` バイナリ導入。

Claude-Session: https://claude.ai/code/session_01YEBocHXrBHtR2pPv7rLQvR

https://claude.ai/code/session_01YEBocHXrBHtR2pPv7rLQvR