### PR TITLE
🔧 chore(aerospace): assign Dia browser to dedicated workspace I

### DIFF
--- a/.config/aerospace/aerospace.toml
+++ b/.config/aerospace/aerospace.toml
@@ -221,6 +221,10 @@ if.app-id = 'com.brave.Browser'
 run = 'move-node-to-workspace B'
 
 [[on-window-detected]]
+if.app-id = 'company.thebrowser.dia'
+run = 'move-node-to-workspace I'
+
+[[on-window-detected]]
 if.app-id = 'com.github.wez.wezterm'
 run = 'move-node-to-workspace 2'
 


### PR DESCRIPTION
## 概要

Dia ブラウザ (`company.thebrowser.dia`) を AeroSpace の専用ワークスペース **I** に固定する。これまで Dia 用の `on-window-detected` ルールが無く、開いたワークスペースで他の窓とタイル分割されていた。

## 変更

`.config/aerospace/aerospace.toml` — ブラウザ群 (Arc→A, Brave→B) の並びに Dia ルールを追加:

```toml
[[on-window-detected]]
if.app-id = 'company.thebrowser.dia'
run = 'move-node-to-workspace I'
```

## 設計判断

- workspace **I** (alt-i) に割当。`D` (dia の頭文字) は Discord で埋まっているため、`dIa` の i から I を採用。
- layout 指定なし (Arc/Brave と同じ)。専用ワークスペースで単独表示になるため分割は発生しない。

## 検証

- `aerospace reload-config` → 設定 valid、エラーなし。
- 既存 Dia 窓を I へ移動 → I には Dia のみ (分割解消) を確認。
- 新規 Dia 窓も今後 I に入る。

Claude-Session: https://claude.ai/code/session_01YEBocHXrBHtR2pPv7rLQvR

https://claude.ai/code/session_01YEBocHXrBHtR2pPv7rLQvR