### PR TITLE
📝 docs(claude-md): debate/設計判断を hub-and-spoke 既定化 (conductor=メイン)

### DIFF
--- a/.config/claude/CLAUDE.md
+++ b/.config/claude/CLAUDE.md
@@ -17,7 +17,7 @@
 - **モデル階層の徹底 (メイン=Fable は指揮 / Opus=推論 / Sonnet=実装)**: メインは判断・統合・最深推論に限定。実装・探索・テストは `Agent(model:'sonnet')` に渡し並列実行、複数ファイル+verify は `Workflow({name:'delegate-implementation'})`、推論サブタスク (Plan 草案・設計分析・根因調査) は `Agent(model:'opus')`。組み込み agent (Explore/Plan/general-purpose) は `model` 明示必須。Tier 表: `references/model-routing.md`
 - **決定表の総索引**: `references/decision-tables-index.md` (どの判断はどこを見れば決まるか)
 - **コード変更後のレビュー**: `/review` skill に従う
-- **ブラッシュアップ系 (improve/debate/absorb) は cmux Worker 優先**: 設計判断・セカンドオピニオン・改善提案は `scripts/runtime/launch-worker.sh --model codex --task ...` で対話ラリー。サブエージェントに逃げない。CI/SSH 単独 (cmux 不在) では `codex exec --sandbox read-only` 直接呼び出しに fallback。`Skill(codex:rescue)` と `Agent(codex:codex-rescue)` は両方失敗事例あり (詳細: memory `feedback_codex_casual_use.md`)
+- **ブラッシュアップ系 (improve/debate/absorb) は cmux Worker で hub-and-spoke (デフォルト)**: 設計判断・セカンドオピニオン・比較は **複数モデルを spoke に並列起動 → メイン=conductor が統合** する (Sakana Fugu の conductor パターンを手作り再現)。subagent/Workflow に逃げない。骨子: `launch-worker.sh --model {codex,claude} --task ...` ×N → `collect-result.sh` で回収 → conductor が統合 (撤退条件つき結論)。詳細手順・運用 tip は `references/cmux-ecosystem.md`。単一視点で足る軽い委譲のみ単発 codex。CI/SSH 単独 (cmux 不在) は `codex exec --sandbox read-only` に fallback。`Skill(codex:rescue)`/`Agent(codex:codex-rescue)` は失敗事例あり (memory `feedback_codex_casual_use.md`)
 - 日本語で応答する
 
 ## コード設計原則

--- a/.config/claude/references/cmux-ecosystem.md
+++ b/.config/claude/references/cmux-ecosystem.md
@@ -97,6 +97,41 @@ $CMUX list-workspaces
 
 **理由**: 同一 workspace に詰め込むとペインが極端に狭くなり、`read-screen` の出力が破損する。
 
+## hub-and-spoke (conductor = メイン Claude)
+
+ブラッシュアップ系 (debate / 設計判断 / セカンドオピニオン / 比較) のデフォルト型。
+複数モデルを spoke に並列起動し、メイン Claude が conductor として統合する。
+Sakana Fugu の「学習済み conductor が役割を割り当てて統合」を、conductor = メイン
+(ルールベース) で手作り再現したもの。
+
+### 手順
+
+```bash
+# 1. spoke を並列起動 (役割を割り当てる: 主張役 / 反証役 / 検証役 など)
+launch-worker.sh --model codex  --task '反証・検証の役割...'   # => workspace:N w-...-codex
+launch-worker.sh --model claude --task '主張・設計の役割...'   # => workspace:M w-...-claude
+
+# 2. 回収 (結果ファイル /tmp/cmux-results/<worker_id>.md を検出)。codex は exec で数分
+#    かかるので background 推奨
+collect-result.sh --workspace workspace:N --worker w-...-codex  --timeout 600
+collect-result.sh --workspace workspace:M --worker w-...-claude --timeout 600
+
+# 3. conductor = メインが両者を統合 → 撤退条件つき結論
+```
+
+### 運用 tip (実証 2026-06-24)
+
+- **env 不要**: `dispatch_logger.sh` が `DISPATCH_RESULT_DIR=/tmp/cmux-results` と
+  `DISPATCH_DONE_SIGNAL` のデフォルトを供給する。`launch-worker.sh` /
+  `collect-result.sh` は `DISPATCH_*` を export せず直接呼べる。
+- **claude worker は workspace が残る** (codex/gemini は成功時に `&& close-workspace`
+  で自動 close)。統合後に `cmux close-workspace --workspace workspace:M` で掃除する。
+- **gemini は sunset** (IneligibleTierError) なので実質 codex + claude の 2 spoke。
+- **独立 context が価値**: 各 spoke は別 workspace = 別 context なので視点が割れる。
+  単一モデルの fan-out (同一 context) より多様性が出る。
+- **多数決・無制限ラリーは品質を上げない** (「収束して見える誤答」を作る)。conductor
+  が撤退条件つきで統合判断するのが核心 — fan-out + judge より文脈適合ルーティング + 検証。
+
 ## cmux-team 4層アーキテクチャ
 
 ```

--- a/.config/claude/templates/claude-md/rules.md
+++ b/.config/claude/templates/claude-md/rules.md
@@ -15,7 +15,7 @@
 - **モデル階層の徹底 (メイン=Fable は指揮 / Opus=推論 / Sonnet=実装)**: メインは判断・統合・最深推論に限定。実装・探索・テストは `Agent(model:'sonnet')` に渡し並列実行、複数ファイル+verify は `Workflow({name:'delegate-implementation'})`、推論サブタスク (Plan 草案・設計分析・根因調査) は `Agent(model:'opus')`。組み込み agent (Explore/Plan/general-purpose) は `model` 明示必須。Tier 表: `references/model-routing.md`
 - **決定表の総索引**: `references/decision-tables-index.md` (どの判断はどこを見れば決まるか)
 - **コード変更後のレビュー**: `/review` skill に従う
-- **ブラッシュアップ系 (improve/debate/absorb) は cmux Worker 優先**: 設計判断・セカンドオピニオン・改善提案は `scripts/runtime/launch-worker.sh --model codex --task ...` で対話ラリー。サブエージェントに逃げない。CI/SSH 単独 (cmux 不在) では `codex exec --sandbox read-only` 直接呼び出しに fallback。`Skill(codex:rescue)` と `Agent(codex:codex-rescue)` は両方失敗事例あり (詳細: memory `feedback_codex_casual_use.md`)
+- **ブラッシュアップ系 (improve/debate/absorb) は cmux Worker で hub-and-spoke (デフォルト)**: 設計判断・セカンドオピニオン・比較は **複数モデルを spoke に並列起動 → メイン=conductor が統合** する (Sakana Fugu の conductor パターンを手作り再現)。subagent/Workflow に逃げない。骨子: `launch-worker.sh --model {codex,claude} --task ...` ×N → `collect-result.sh` で回収 → conductor が統合 (撤退条件つき結論)。詳細手順・運用 tip は `references/cmux-ecosystem.md`。単一視点で足る軽い委譲のみ単発 codex。CI/SSH 単独 (cmux 不在) は `codex exec --sandbox read-only` に fallback。`Skill(codex:rescue)`/`Agent(codex:codex-rescue)` は失敗事例あり (memory `feedback_codex_casual_use.md`)
 - 日本語で応答する
 
 ## コード設計原則


### PR DESCRIPTION
## 背景

debate・設計判断・セカンドオピニオン系で「cmux Worker 優先」規約は既に rules.md にあったが、単一 codex 委譲止まりで **hub-and-spoke (複数 spoke 並列 → conductor 統合) という型が無く**、実際にメインが subagent/Workflow に逃げる未発火が起きていた (`feedback_sonnet_cursor_underused` と同型)。Sakana Fugu の学習済み conductor を、conductor=メイン (ルールベース) で手作り再現する型をデフォルトに固定する。

## 変更

- **rules.md**: 「cmux Worker 優先」を hub-and-spoke 型に強化 (複数モデルを spoke に並列起動 → メイン=conductor が統合、撤退条件つき結論)。既存の fallback・codex:rescue 失敗注記は保持。
- **cmux-ecosystem.md**: hub-and-spoke の詳細手順 + 実証 tip を Progressive Disclosure で追記。
- **CLAUDE.md**: `build-claude.sh` で再生成 (生成物)。

## 実証 tip (2026-06-24 セッションで検証)

- `dispatch_logger.sh` が `DISPATCH_*` のデフォルトを供給 → `launch-worker.sh`/`collect-result.sh` は env なしで直接呼べる
- **claude worker は workspace が残る** (codex/gemini は成功時自動 close) → 統合後に手動 close
- gemini は sunset で実質 codex + claude の 2 spoke
- 独立 context で視点が割れるのが価値、多数決・無制限ラリーは品質を上げない

## 検証

- `build-claude.sh --check` 整合 OK
- `task validate-configs` 通過
- lefthook pre-commit (build-claude-check / check-claudemd-lines / conventional-commit) 全 pass
- symlink 構造は無変更 (既存ファイルの内容編集のみ)

## 非対象 (YAGNI)

発火 mechanism (advisory hook) は足さない。CLAUDE.md が毎 session 読まれることで担保し、未発火が続いたら後出しする。

https://claude.ai/code/session_01GfdWynSpbJWPXiZMqzY276