### PR TITLE
🔥 chore(skills): #132 が取りこぼした ai-workflow-audit 幽霊参照を除去

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 
 ## Codex Skills
 - project-local skills は `.agents/skills/`、selected skill は compatibility のため `~/.codex/skills/` と `~/.agents/skills/` の両方へ公開する
-- 主な候補: `$codex-search-first` (実装前調査) / `$ai-workflow-audit` (harness 改善・横展開判断) / `$codex-obsidian-knowledge` (Codex から Obsidian Vault 検索・参照) / `$openai-frontend-prompt-workflow` (GPT-5.4 frontend prompt) / `$frontend-skill` (visually strong UI) / `$github-review-workflow` (PR / CI) / `$artifact-workflow` (doc/pdf/slides) / `$codex-verification-before-completion` / `$dotfiles-config-validation` / `$codex-checkpoint-resume` / `$codex-memory-capture` / `$codex-session-hygiene`
+- 主な候補: `$codex-search-first` (実装前調査) / `$codex-obsidian-knowledge` (Codex から Obsidian Vault 検索・参照) / `$openai-frontend-prompt-workflow` (GPT-5.4 frontend prompt) / `$frontend-skill` (visually strong UI) / `$github-review-workflow` (PR / CI) / `$artifact-workflow` (doc/pdf/slides) / `$codex-verification-before-completion` / `$dotfiles-config-validation` / `$codex-checkpoint-resume` / `$codex-memory-capture` / `$codex-session-hygiene`
 - Claude 向け skill を参照する場合は、Claude 固有の `Agent`、`AskUserQuestion`、slash command、plugin 前提をそのまま実行せず、文書として必要部分だけ採用する
 
 ## Frontend UI Work
@@ -53,7 +53,6 @@
 
 ## Mandatory Skill Usage
 - 実装前の調査: `$codex-search-first`
-- harness 改善・workflow 設計・他 repo への横展開判断: `$ai-workflow-audit`
 - 完了前の検証コマンド選定: `$dotfiles-config-validation`
 - 30 分以上 / handoff / resume / compact が絡む作業: `$codex-checkpoint-resume`
 - 同じ長時間タスクで thread 継続や再開判断: `$codex-session-hygiene`

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Cursor エディタの AI 設定。rules・skills・agents・hooks で構成。
 | [AGENTS.md](AGENTS.md) | エージェント向け contract |
 | [PLANS.md](PLANS.md) | 長時間・複数ステップ作業の plan contract |
 | [docs/agent-harness-contract.md](docs/agent-harness-contract.md) | Claude / Codex 共通ハーネス contract |
-| [docs/guides/ai-workflow-audit.md](docs/guides/ai-workflow-audit.md) | AI workflow の監査と昇格基準 |
 | [docs/playbooks/](docs/playbooks/) | 変更手順の playbook |
 | [docs/adr/](docs/adr/) | Architecture Decision Records |
 


### PR DESCRIPTION
## 背景

`#132 (ai-workflow-audit 撤去)` の sweep が live doc 2件を取りこぼしていた。`/review` (ハーネス変更の mandatory review) で検出。

## 変更

- `README.md` — 削除済み `docs/guides/ai-workflow-audit.md` への broken link を除去
- `AGENTS.md` — `$ai-workflow-audit` 参照を 2箇所 (Codex Skills 候補 / Mandatory Skill Usage) 除去

検証: `validate-configs` / `validate-symlinks` pass、dangling symlink なし、live (非HTML) の幽霊参照ゼロを確認。

## 別途対応 (このPRに含めない)

`.config/claude/docs/architecture.html` と `docs/share/ai-harness-overview.html` は ai-workflow-audit に加え `autonomous` / `morning-briefing` / `analyze-tacit-knowledge` 等 **5件以上の削除済み skill を含む stale snapshot**。per-skill 編集ではなく**まとめて再生成**すべきため別タスクに切り分け。

https://claude.ai/code/session_01PgR8XBKNVNmVw1JZ8mvktn