### PR TITLE
✨ feat(nightly): security-scan (AgentShield 静的監査) を復活

### DIFF
--- a/scripts/runtime/nightly/run-security-scan.sh
+++ b/scripts/runtime/nightly/run-security-scan.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# run-security-scan.sh — AgentShield エージェント設定セキュリティ監査 (静的)
+# cron: 45 23 * * *  (DOW=3 水曜、catch-up 6 days)
+# Scope: ~/.claude/ のエージェント設定 (CLAUDE.md / hooks / skills / settings.json)。
+# agentshield-filter.py が `npx ecc-agentshield scan` を実行し、deny ルール等の
+# false positive を除去して再採点する (skill `/security-scan` の非対話版)。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./lib/nightly-status.sh
+source "${SCRIPT_DIR}/lib/nightly-status.sh"
+
+TASK="security-scan"
+DOTFILES_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+FILTER="${DOTFILES_DIR}/.config/claude/scripts/policy/agentshield-filter.py"
+SCAN_TARGET="${SECURITY_SCAN_PATH:-$HOME/.claude}"
+
+_cleanup() {
+    local ec=$?
+    if [[ -n "${_NIGHTLY_CURRENT_TASK:-}" ]]; then
+        status_end fail "trapped exit_code=$ec"
+    fi
+}
+trap _cleanup EXIT
+
+if [[ -z "${OBSIDIAN_VAULT_PATH:-}" ]]; then
+    status_begin "$TASK"; status_end fail "missing OBSIDIAN_VAULT_PATH"
+    exit 0
+fi
+for cmd in jq python3 npx; do
+    if ! command -v "$cmd" &>/dev/null; then
+        status_begin "$TASK"; status_end fail "preflight: $cmd CLI not found"
+        exit 0
+    fi
+done
+if [[ ! -f "$FILTER" ]]; then
+    status_begin "$TASK"; status_end fail "preflight: filter not found ($FILTER)"
+    exit 0
+fi
+
+should_run_today "$TASK" DOW 3 6 || exit 0
+status_begin "$TASK"
+
+REPORT_DIR="${OBSIDIAN_VAULT_PATH}/06-Nightly"
+mkdir -p "$REPORT_DIR"
+REPORT_PATH="${REPORT_DIR}/${NIGHTLY_DATE}-security.md"
+JSON_TMP=$(mktemp -t "nightly-security-${NIGHTLY_DATE}.XXXXXX")
+ERR_TMP="${JSON_TMP}.err"
+trap 'rm -f "$JSON_TMP" "$ERR_TMP"; _cleanup' EXIT
+
+# agentshield-filter.py の exit code: 0=clean / 1=critical findings あり (正常動作) / 2=実行・parse エラー
+# → exit 1 を fail 扱いしない (critical 件数はレポート + metric に出す)。
+SCAN_EC=0
+python3 "$FILTER" --path "$SCAN_TARGET" --format json >"$JSON_TMP" 2>"$ERR_TMP" || SCAN_EC=$?
+if [[ "$SCAN_EC" -ge 2 ]]; then
+    status_end fail "agentshield error (ec=$SCAN_EC): $(head -c 200 "$ERR_TMP" 2>/dev/null | tr '\n' ' ')"
+    exit 0
+fi
+
+# 出力検証 (silent failure 回避: grade が取れなければ異常として fail し握り潰さない)
+GRADE=$(jq -re '.score.grade' "$JSON_TMP" 2>/dev/null) || {
+    status_end fail "agentshield output has no .score.grade (ec=$SCAN_EC)"
+    exit 0
+}
+SCORE=$(jq -r '.score.numericScore' "$JSON_TMP")
+TOTAL=$(jq -r '.summary.totalFindings' "$JSON_TMP")
+CRIT=$(jq -r '.summary.critical' "$JSON_TMP")
+HIGH=$(jq -r '.summary.high' "$JSON_TMP")
+SUPPRESSED=$(jq -r '.suppressed' "$JSON_TMP")
+FILES=$(jq -r '.summary.filesScanned' "$JSON_TMP")
+
+{
+    echo "# Security Scan (AgentShield) ${NIGHTLY_DATE}"
+    echo ""
+    echo "Scope: ${SCAN_TARGET/#$HOME/~} (CLAUDE.md / hooks / skills / settings.json)"
+    echo ""
+    echo "- Grade: **${GRADE}** (${SCORE}/100)"
+    echo "- Findings: ${TOTAL} (critical=${CRIT} high=${HIGH})"
+    echo "- Suppressed false positives: ${SUPPRESSED}"
+    echo "- Files scanned: ${FILES}"
+    echo ""
+    echo "## Findings"
+    jq -r '(.findings // []) | if length == 0 then "なし" else (.[] | "- [\(.severity | ascii_upcase)] \(.title) — \(.file)\(if .line then ":\(.line | tostring)" else "" end)") end' "$JSON_TMP"
+} > "$REPORT_PATH"
+
+DETAIL="grade=$GRADE score=$SCORE critical=$CRIT high=$HIGH suppressed=$SUPPRESSED"
+TOP=$(jq -r '(.findings // []) | map(select(.severity == "critical" or .severity == "high")) | .[0:5][] | "[\(.severity | ascii_upcase)] \(.title) — \(.file)"' "$JSON_TMP" 2>/dev/null || true)
+[[ -n "$TOP" ]] && DETAIL+=$'\n\nTop findings:\n'"$TOP"
+
+status_end ok "grade=$GRADE score=$SCORE critical=$CRIT high=$HIGH" \
+    "report=06-Nightly/${NIGHTLY_DATE}-security.md" \
+    "metric.score=$SCORE" "metric.critical=$CRIT" "metric.high=$HIGH" \
+    "detail=$DETAIL"

--- a/tools/nightly-orchestrator/jobs.yaml
+++ b/tools/nightly-orchestrator/jobs.yaml
@@ -35,6 +35,10 @@ jobs:
     script: scripts/runtime/nightly/run-skill-audit.sh
     timeout_sec: 1080
     retry: 1
+  - name: security-scan
+    script: scripts/runtime/nightly/run-security-scan.sh
+    timeout_sec: 600
+    retry: 1
   - name: plan-close-scan
     script: scripts/runtime/nightly/run-plan-close-scan.sh
     timeout_sec: 300


### PR DESCRIPTION
## 背景

`#132 (ai-workflow-audit 撤去)` が landed した際、同じ作業ブランチにあった nightly **security-scan** (script + jobs.yaml 配線) が working tree から落ちてしまった。本 PR で復活させる。

script の内容はドロップ前にレビュー済み (依存・出力スキーマ・exit code 契約・sibling 規約を検証、clean 判定)。本 PR は同一内容を忠実に復元したもの。

## 変更

- `scripts/runtime/nightly/run-security-scan.sh` (新規, 実行ビット付) — AgentShield エージェント設定セキュリティ監査。`agentshield-filter.py` 経由で deny ルール等の false positive を除去して再採点 (skill `/security-scan` の非対話版)。レポートは Vault `06-Nightly/<date>-security.md`
- `tools/nightly-orchestrator/jobs.yaml` — `security-scan` ジョブを配線 (timeout 600s / retry 1)

## ゲート設計

- `should_run_today DOW 3 6` — 水曜実行 + catch-up 6 日
- exit code: filter の `0=clean / 1=critical あり (正常) / 2=実行エラー` を解釈し、exit 1 を fail 扱いせず critical 件数を report+metric に出す
- silent failure 回避: `.score.grade` が取れなければ fail で握り潰さない

## 検証

- `bash -n` syntax OK、実行ビット `-rwxr-xr-x`
- 依存健在: `agentshield-filter.py` / `lib/nightly-status.sh`、出力スキーマ (`grade`/`numericScore`/`summary.*`) 一致
- `jobs.yaml` YAML 妥当 + Go struct タグ (`name`/`script`/`timeout_sec`/`retry`) 整合
- `validate-configs` pass

https://claude.ai/code/session_01PgR8XBKNVNmVw1JZ8mvktn