### PR TITLE
✨ feat(hooks): memory-vec recall hook で判断 turn に Vault を機械引き

### DIFF
--- a/.config/claude/scripts/runtime/memory-vec-recall-hook.py
+++ b/.config/claude/scripts/runtime/memory-vec-recall-hook.py
@@ -43,9 +43,9 @@ TOP_K = 3
 STDERR_LOG_CAP = 500
 
 # Intent gate. Japanese terms are matched as plain substrings (\b misbehaves on
-# Japanese — see memory). English terms get an ASCII boundary guard so "design"
-# does not fire inside unrelated tokens. Mirrors the CLAUDE.md judgment/decision
-# /research condition that this hook makes deterministic.
+# Japanese — see memory). English terms get a leading ASCII boundary guard so
+# "decide" does not fire inside "undecided". Mirrors the CLAUDE.md judgment
+# /decision/research condition that this hook makes deterministic.
 _JP_TERMS = (
     "どっち",
     "どちら",

--- a/.config/claude/scripts/runtime/memory-vec-recall-hook.py
+++ b/.config/claude/scripts/runtime/memory-vec-recall-hook.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Memory vector recall UserPromptSubmit hook.
+
+Mechanizes the CLAUDE.md `<important if="...judgment/decision/research...">` rule:
+when the prompt looks like a judgment / design / research turn, run a semantic
+top-K against the Vault slice of ~/.claude/skill-data/memory-vec/index.db and
+print a PATH-ONLY [Vault Recall] block. File body is never included — the agent
+expands with Read on demand (pointer push, body pull).
+
+Why gate on prompt intent, not distance: the index corpus is topically
+homogeneous (all AI/agent/dotfiles), so cosine distance cannot separate
+"needs Vault knowledge" from routine coding (off-topic floor ~1.17 overlaps
+on-topic top ~1.12). The signal is in the prompt intent. Distance is demoted
+to a loose garbage filter only.
+
+Runs on EVERY prompt, so the gate (`is_intent_prompt`) is pure regex with no
+subprocess — non-matching turns cost ~0 and cannot fail. The query.ts
+subprocess fires only on a gate match. Always exits 0 (must never block a
+prompt). Mirrors memory-vec-hint-hook.py hardening.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+SKILL_DATA = Path.home() / ".claude" / "skill-data" / "memory-vec"
+INDEX_DB = SKILL_DATA / "index.db"
+QUERY_SCRIPT = SKILL_DATA / "query.ts"
+LOG_FILE = Path.home() / ".claude" / "logs" / "memory-vec.log"
+REDACTOR_LIB = SKILL_DATA / "lib"
+
+QUERY_TIMEOUT_SEC = 8.0
+QUERY_MAX_CHARS = 2000
+DISTANCE_THRESHOLD = 1.3
+TOP_K = 3
+STDERR_LOG_CAP = 500
+
+# Intent gate. Japanese terms are matched as plain substrings (\b misbehaves on
+# Japanese — see memory). English terms get an ASCII boundary guard so "design"
+# does not fire inside unrelated tokens. Mirrors the CLAUDE.md judgment/decision
+# /research condition that this hook makes deterministic.
+_JP_TERMS = (
+    "どっち",
+    "どちら",
+    "比較",
+    "トレードオフ",
+    "採用",
+    "導入",
+    "選定",
+    "選ぶ",
+    "判断",
+    "決め",
+    "決断",
+    "設計",
+    "方針",
+    "検討",
+    "評価",
+    "レビュー",
+    "移行",
+    "べきか",
+    "すべき",
+    "メリット",
+    "デメリット",
+    "良い方法",
+    "どうする",
+    "技術選定",
+    "セカンドオピニオン",
+    "意見",
+)
+_EN_TERMS = (
+    "should i",
+    "trade-off",
+    "tradeoff",
+    "compare",
+    "comparison",
+    "decide",
+    "decision",
+    "evaluate",
+    "which is better",
+    "approach",
+    "adopt",
+    "vs ",
+    "pros and cons",
+    "design",
+    "second opinion",
+)
+_JP_PATTERN = re.compile("|".join(re.escape(t) for t in _JP_TERMS))
+_EN_PATTERN = re.compile("|".join(f"(?<![a-z0-9]){re.escape(t)}" for t in _EN_TERMS))
+
+
+def is_intent_prompt(prompt: str) -> bool:
+    """True when the prompt reads as a judgment/design/research turn."""
+    if not prompt or not prompt.strip():
+        return False
+    lowered = prompt.lower()
+    return bool(_JP_PATTERN.search(prompt) or _EN_PATTERN.search(lowered))
+
+
+def _resolve_node() -> str | None:
+    return shutil.which("node")
+
+
+def _scrub(text: str) -> str:
+    if not text:
+        return text
+    try:
+        if str(REDACTOR_LIB) not in sys.path:
+            sys.path.insert(0, str(REDACTOR_LIB))
+        from memory_redactor import redact_for_embedding  # type: ignore
+
+        return redact_for_embedding(text)
+    except (ImportError, OSError, ValueError) as exc:
+        truncated = text if len(text) <= 200 else f"{text[:200]}... [truncated]"
+        return f"[REDACT_UNAVAILABLE: {type(exc).__name__}] {truncated}"
+
+
+def _log(stage: str, error: BaseException, extra: dict | None = None) -> None:
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        entry: dict = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "source": "memory-vec-recall-hook",
+            "stage": stage,
+            "error": _scrub(f"{type(error).__name__}: {error}"),
+            "traceback": _scrub(traceback.format_exc()),
+        }
+        if extra:
+            entry.update({k: _scrub(str(v)) for k, v in extra.items()})
+        with LOG_FILE.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except OSError:
+        return
+
+
+def _log_event(stage: str, payload: dict) -> None:
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        entry: dict = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "source": "memory-vec-recall-hook",
+            "stage": stage,
+        }
+        for k, v in payload.items():
+            entry[k] = _scrub(str(v)) if isinstance(v, str) else v
+        with LOG_FILE.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except OSError:
+        return
+
+
+def _read_prompt() -> str | None:
+    """Read the prompt from the UserPromptSubmit payload."""
+    try:
+        raw = sys.stdin.read()
+        if not raw:
+            return None
+        payload = json.loads(raw)
+        prompt = payload.get("prompt")
+        if isinstance(prompt, str) and prompt.strip():
+            return prompt
+    except (OSError, ValueError, TypeError) as exc:
+        _log("payload_parse", exc)
+    return None
+
+
+def _run_query(query: str, node_bin: str) -> list[dict] | None:
+    if not INDEX_DB.is_file() or not QUERY_SCRIPT.is_file():
+        return None
+    try:
+        result = subprocess.run(
+            [
+                node_bin,
+                "--experimental-strip-types",
+                "--no-warnings",
+                str(QUERY_SCRIPT),
+                query[:QUERY_MAX_CHARS],
+                "--source",
+                "vault",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=QUERY_TIMEOUT_SEC,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        _log("query_subprocess", exc)
+        return None
+
+    if result.returncode != 0:
+        _log_event(
+            "query_nonzero",
+            {
+                "returncode": result.returncode,
+                "stderr": (result.stderr or "")[:STDERR_LOG_CAP],
+            },
+        )
+        return None
+    if not result.stdout.strip():
+        return None
+    try:
+        rows = json.loads(result.stdout)
+    except ValueError as exc:
+        _log("query_parse", exc)
+        return None
+    return rows if isinstance(rows, list) else None
+
+
+def _format_hint(rows: list[dict]) -> str:
+    filtered = [
+        r
+        for r in rows
+        if isinstance(r, dict)
+        and isinstance(r.get("distance"), (int, float))
+        and r["distance"] < DISTANCE_THRESHOLD
+        and isinstance(r.get("path"), str)
+    ][:TOP_K]
+    if not filtered:
+        return ""
+
+    lines = [
+        "[Vault Recall] この判断に関連しうる Vault ノート (top-{0}, ephemeral):".format(
+            len(filtered)
+        )
+    ]
+    for r in filtered:
+        lines.append(f"- {r['path']} (rel: {r['distance']:.2f})")
+    lines.append("")
+    lines.append(
+        "必要時のみ Read で展開。Vault は単方向同期のスナップショット — "
+        "現行コード/事実と矛盾したら現状を優先。本 hint に file 内容は含まれません。"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    prompt = _read_prompt()
+    if prompt is None or not is_intent_prompt(prompt):
+        return 0
+
+    node_bin = _resolve_node()
+    if node_bin is None:
+        _log_event("node_missing", {"note": "node binary not found in PATH"})
+        return 0
+
+    rows = _run_query(prompt, node_bin)
+    if rows is None:
+        return 0
+
+    hint = _format_hint(rows)
+    if hint:
+        sys.stdout.write(hint)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001
+        _log("unhandled", exc)
+        sys.exit(0)

--- a/.config/claude/scripts/runtime/memory-vec-recall-hook.py
+++ b/.config/claude/scripts/runtime/memory-vec-recall-hook.py
@@ -84,11 +84,8 @@ _EN_TERMS = (
     "decision",
     "evaluate",
     "which is better",
-    "approach",
     "adopt",
-    "vs ",
     "pros and cons",
-    "design",
     "second opinion",
 )
 _JP_PATTERN = re.compile("|".join(re.escape(t) for t in _JP_TERMS))
@@ -165,6 +162,14 @@ def _read_prompt() -> str | None:
         prompt = payload.get("prompt")
         if isinstance(prompt, str) and prompt.strip():
             return prompt
+        _log_event(
+            "prompt_unusable",
+            {
+                "keys": list(payload)
+                if isinstance(payload, dict)
+                else type(payload).__name__
+            },
+        )
     except (OSError, ValueError, TypeError) as exc:
         _log("payload_parse", exc)
     return None
@@ -172,6 +177,10 @@ def _read_prompt() -> str | None:
 
 def _run_query(query: str, node_bin: str) -> list[dict] | None:
     if not INDEX_DB.is_file() or not QUERY_SCRIPT.is_file():
+        _log_event(
+            "index_unavailable",
+            {"index_db": INDEX_DB.is_file(), "query_script": QUERY_SCRIPT.is_file()},
+        )
         return None
     try:
         result = subprocess.run(

--- a/.config/claude/scripts/tests/test_memory_vec_recall.py
+++ b/.config/claude/scripts/tests/test_memory_vec_recall.py
@@ -1,0 +1,53 @@
+"""Gate logic tests for memory-vec-recall-hook.
+
+The hook runs on every prompt, so the only non-trivial decision — whether a
+prompt is a judgment/design/research turn worth a Vault query — must hold.
+Coding/routine prompts must NOT fire (else every turn pays a subprocess and
+pollutes context).
+"""
+
+import importlib.util
+from pathlib import Path
+
+_HOOK = Path(__file__).resolve().parents[1] / "runtime" / "memory-vec-recall-hook.py"
+_spec = importlib.util.spec_from_file_location("recall_hook", _HOOK)
+recall_hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(recall_hook)
+is_intent_prompt = recall_hook.is_intent_prompt
+
+
+def test_judgment_prompts_fire():
+    for p in [
+        "この obsidian repo を導入すべきか",
+        "A と B どっちが良い",
+        "memory retrieval をどう設計する",
+        "should I adopt this approach",
+        "compare these two designs",
+        "trade-off を整理して",
+        "この技術選定についてセカンドオピニオンが欲しい",
+    ]:
+        assert is_intent_prompt(p), p
+
+
+def test_routine_prompts_do_not_fire():
+    for p in [
+        "fix the typo on line 42",
+        "この関数の変数名をリネームして",
+        "run the tests",
+        "git status を見せて",
+        "add a log line here",
+        "import を整理して消す",
+    ]:
+        assert not is_intent_prompt(p), p
+
+
+def test_empty_is_false():
+    assert not is_intent_prompt("")
+    assert not is_intent_prompt("   ")
+
+
+def test_english_boundary_guard():
+    # "design" must fire, but it should be a real word, not a substring hit
+    # inside an unrelated token.
+    assert is_intent_prompt("review the design doc")
+    assert not is_intent_prompt("update the redesignation field")

--- a/.config/claude/scripts/tests/test_memory_vec_recall.py
+++ b/.config/claude/scripts/tests/test_memory_vec_recall.py
@@ -37,6 +37,9 @@ def test_routine_prompts_do_not_fire():
         "git status を見せて",
         "add a log line here",
         "import を整理して消す",
+        "fix the bug in design.py",
+        "vs code is my editor",
+        "this approach is fine, ship it",
     ]:
         assert not is_intent_prompt(p), p
 
@@ -46,8 +49,22 @@ def test_empty_is_false():
     assert not is_intent_prompt("   ")
 
 
-def test_english_boundary_guard():
-    # "design" must fire, but it should be a real word, not a substring hit
-    # inside an unrelated token.
-    assert is_intent_prompt("review the design doc")
-    assert not is_intent_prompt("update the redesignation field")
+def test_english_leading_boundary_guard():
+    assert is_intent_prompt("let's decide now")
+    assert not is_intent_prompt("this is still undecided for now")
+
+
+def test_format_hint_distance_filter():
+    rows = [
+        {"path": "/v/near.md", "name": "near", "distance": 1.2},
+        {"path": "/v/far.md", "name": "far", "distance": 1.4},
+    ]
+    out = recall_hook._format_hint(rows)
+    assert "/v/near.md" in out
+    assert "/v/far.md" not in out
+    assert (
+        recall_hook._format_hint(
+            [{"path": "/v/far.md", "name": "far", "distance": 1.9}]
+        )
+        == ""
+    )

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -408,6 +408,16 @@
             "statusMessage": "Input guard..."
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/scripts/runtime/memory-vec-recall-hook.py",
+            "timeout": 10,
+            "statusMessage": "Vault recall..."
+          }
+        ]
       }
     ],
     "PreToolUse": [


### PR DESCRIPTION
## 背景

「claude-obsidian-assistant を導入したいかも」の grill から出発し、リポジトリ実体を確認したところ、唯一の net-new (Canvas) は既存 `obsidian:json-canvas` で代替可、memory/sync モデルは dotfiles の単方向設計と逆で退行を招くと判明。fork はしない。

代わりに**本当の摩擦「AI が Vault を使わない」を解く。** 真因は非対称:

- **write 経路** (memory→Vault): `sync-memory-to-vault.sh` 等を hook で機械化済み
- **read 経路** (Vault→agent): CLAUDE.md の `<important if=judgment/decision/research>` prose 指示だけ → 確率的にしか発火しない

`memory-vec` エンジン・索引 (`05-Literature` 83ノート等) は既に存在 (cold 0.59s / warm 0.25s 実測)。足りないのは「推論 turn で Vault を引くトリガー」だけ。

## 変更

新 `UserPromptSubmit` hook `memory-vec-recall-hook.py` で既存 prose ルールを mechanism 化 (「static rule → mechanism」原則)。

- 判断/設計/リサーチ intent の prompt のみ `query.ts --source vault` → top-3 を **path-only pointer** で additionalContext に差す。本文は agent が Read (pointer push / body pull)
- gate (`is_intent_prompt`) は**純正規表現・subprocess なし** → 非 match turn はコスト≈0・失敗不能・汚染0
- 距離は緩い床 (<1.3) で garbage 落としのみ。intent 判別は gate が担う

### なぜ距離ゲートではなく intent ゲートか (実測)

索引コーパスが topically homogeneous (全部 AI/agent/dotfiles) ゆえ距離が intent を判別できない:

| prompt | 最近傍 distance |
|---|---|
| (off) typo を42行目で直す | 1.166 |
| (on) この repo 導入すべきか | 1.124 |
| (on) memory retrieval をどう発火 | 1.149 |

on/off が重複 → clean に切れる閾値が存在しない。signal は prompt intent にある。

## 安全性

`UserPromptSubmit` は毎 prompt 発火する高リスク面なので:

- gate 判定は純 Python (subprocess なし) → コーディング turn は即 `return 0`
- `query.ts` subprocess は match 時のみ、timeout 8s、**常に exit 0** (graceful degradation、hint-hook 踏襲)
- redactor 経由ログ・node PATH hijack 回避を hint-hook から継承

## テスト・検証

- `test_memory_vec_recall.py` 4件 pass (判断 prompt 発火 / コーディング prompt 非発火 / 空文字 / 英語境界ガード)
- end-to-end スモーク: 判断 prompt → [Vault Recall] block / コーディング prompt → 空 (exit 0)
- `task validate-configs` pass、ruff clean、lefthook 全 pass
- `validate-symlinks` の失敗は master でも出る pre-existing (本変更と無関係)

## デプロイ

nix `mkOutOfStoreSymlink` で `.claude/scripts` はディレクトリごと live symlink、`.claude/settings.json` も live。**master マージ後は nix:switch 不要で即反映** (home.file エントリ追加なし)。

https://claude.ai/code/session_01TYkjwiqAJF6FAxzpbGgqaQ