### PR TITLE
🔧 learned 昇格 20260628-222524 (adopted=1 rejected=4)

### DIFF
--- a/.config/claude/skills/hook-debugger/SKILL.md
+++ b/.config/claude/skills/hook-debugger/SKILL.md
@@ -86,6 +86,7 @@ grep -A 5 'timeout' ~/.claude/settings.json ~/.claude/settings.local.json
 
 - **shebang 行**: `#!/usr/bin/env python3` がないと実行環境が不定になる
 - **stdin の消費**: PreToolUse/PostToolUse は stdin から JSON を読む。`input()` で先に読むと `json.load(sys.stdin)` が空になる
+- **イベント境界**: Python や shell が直接 agent-memory 等へ書く I/O は Write/Edit tool ではないため、PostToolUse(Write|Edit) は発火しない。session learner や集約処理は Stop/SessionEnd hook か明示的な emit 経路で扱う
 - **PATH の違い**: hook 実行時の PATH はユーザーのシェルと異なる場合がある。フルパス推奨
 - **並行実行**: 同じイベントに複数の hook が登録されている場合、実行順序は保証されない
 - **SKILL.md hooks vs settings.json hooks**: SKILL.md の hooks はスキルが active な時のみ有効。settings.json はグローバル

--- a/docs/learned-promote/20260628-222524.json
+++ b/docs/learned-promote/20260628-222524.json
@@ -1,0 +1,42 @@
+{
+  "date": "2026-06-28",
+  "branch": "auto/learned-promote-20260628-222524",
+  "max": 5,
+  "promotions": [
+    {
+      "key": "7ff54e1f8c0f2788c8926e275bb94734cfeae2da",
+      "decision": "rejected",
+      "scope": "adversarial-review",
+      "reason": "already covered: .config/claude/agents/codex-reviewer.md",
+      "detail_excerpt": "単一モデルの盲点は異モデルレビューで排除"
+    },
+    {
+      "key": "dae320b2475987bec7c7fec6f55e59a75c4d7ab0",
+      "decision": "rejected",
+      "scope": "regex-extraction",
+      "reason": "manual: .config/claude/scripts/policy/stagnation-detector.py",
+      "detail_excerpt": "Error/Exception regex は1文字しか拾わない"
+    },
+    {
+      "key": "b299d9c5effbc93a5924d5f4ed66fb6a3730696e",
+      "decision": "rejected",
+      "scope": "skill-contract",
+      "reason": "already covered: .config/claude/skills/skill-creator/instructions/skill-writing-guide.md",
+      "detail_excerpt": "書くことと生成中の毎回照合は別物"
+    },
+    {
+      "key": "127ee9c35f0005441b6a833437f5c80c667b1f85",
+      "decision": "adopted",
+      "scope": "session-learner",
+      "target_artifact": ".config/claude/skills/hook-debugger/SKILL.md",
+      "detail_excerpt": "Python I/O では PostToolUse Write/Edit が発火しない"
+    },
+    {
+      "key": "f227d712355c9b89a2ad48189f9db661ee319277",
+      "decision": "rejected",
+      "scope": "analyzer-bias",
+      "reason": "already covered: .config/claude/skills/absorb/SKILL.md",
+      "detail_excerpt": "Phase 2.5 Refine はスキップ不可"
+    }
+  ]
+}


### PR DESCRIPTION
## learned 昇格 (自動生成・人間ゲート = この PR)

nightly `run-learned-promote.sh` が 20260628-222524 の昇格候補 5 件を非対話 promote しました。

- **adopted**: 1 件 (artifact へ追記)
- **rejected**: 4 件 (already covered 等)

### レビュー観点
- 各 artifact 編集が知見を正しく・簡潔に反映しているか
- 同一 scope への偏り (echo chamber) がないか
- 誤爆 (既存と重複) を adopted にしていないか

### Calibration 裁定 (レビューしながら 1 行コピペ・任意)
各候補の自動判断 (adopted/rejected) に同意なら該当行をそのまま実行、不同意なら `--verdict disagree` に変えて実行:

```bash
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key '7ff54e1f8c0f2788c8926e275bb94734cfeae2da' --scope 'adversarial-review' --auto 'rejected' --verdict agree --report '20260628-222524'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'dae320b2475987bec7c7fec6f55e59a75c4d7ab0' --scope 'regex-extraction' --auto 'rejected' --verdict agree --report '20260628-222524'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'b299d9c5effbc93a5924d5f4ed66fb6a3730696e' --scope 'skill-contract' --auto 'rejected' --verdict agree --report '20260628-222524'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key '127ee9c35f0005441b6a833437f5c80c667b1f85' --scope 'session-learner' --auto 'adopted' --verdict agree --report '20260628-222524'
python3 ~/.claude/scripts/learner/calibration-verdict-logger.py log --source promote --key 'f227d712355c9b89a2ad48189f9db661ee319277' --scope 'analyzer-bias' --auto 'rejected' --verdict agree --report '20260628-222524'
```

裁定は `triage-calibration.jsonl` に蓄積され、`calibration-verdict-logger.py stats` で
agreement rate (判断 frontier 指標) を集計できます。

### マージ後
manifest (`docs/learned-promote/20260628-222524.json`) が master に入ると、次回 nightly の
reconcile が processed key を promoted-ledger に記録し、再提案されなくなります。
**却下する場合はこの PR を close** してください (key は ledger に入らず、後で再提案されます)。

<details><summary>manifest</summary>

```json
{
  "date": "2026-06-28",
  "branch": "auto/learned-promote-20260628-222524",
  "max": 5,
  "promotions": [
    {
      "key": "7ff54e1f8c0f2788c8926e275bb94734cfeae2da",
      "decision": "rejected",
      "scope": "adversarial-review",
      "reason": "already covered: .config/claude/agents/codex-reviewer.md",
      "detail_excerpt": "単一モデルの盲点は異モデルレビューで排除"
    },
    {
      "key": "dae320b2475987bec7c7fec6f55e59a75c4d7ab0",
      "decision": "rejected",
      "scope": "regex-extraction",
      "reason": "manual: .config/claude/scripts/policy/stagnation-detector.py",
      "detail_excerpt": "Error/Exception regex は1文字しか拾わない"
    },
    {
      "key": "b299d9c5effbc93a5924d5f4ed66fb6a3730696e",
      "decision": "rejected",
      "scope": "skill-contract",
      "reason": "already covered: .config/claude/skills/skill-creator/instructions/skill-writing-guide.md",
      "detail_excerpt": "書くことと生成中の毎回照合は別物"
    },
    {
      "key": "127ee9c35f0005441b6a833437f5c80c667b1f85",
      "decision": "adopted",
      "scope": "session-learner",
      "target_artifact": ".config/claude/skills/hook-debugger/SKILL.md",
      "detail_excerpt": "Python I/O では PostToolUse Write/Edit が発火しない"
    },
    {
      "key": "f227d712355c9b89a2ad48189f9db661ee319277",
      "decision": "rejected",
      "scope": "analyzer-bias",
      "reason": "already covered: .config/claude/skills/absorb/SKILL.md",
      "detail_excerpt": "Phase 2.5 Refine はスキップ不可"
    }
  ]
}
```
</details>