### PR TITLE
✨ feat(hooks): completion-gate に捏造完了主張ゲートを追加

### DIFF
--- a/.config/claude/scripts/policy/completion-gate.py
+++ b/.config/claude/scripts/policy/completion-gate.py
@@ -1081,11 +1081,58 @@ _CLAIM_GATE_MARKER_DIR = os.path.join(
 )
 
 _CLAIM_VERB_RE = re.compile(
-    r"(?:書いた|書き出した|書き込んだ|作成した|作成しました|生成した|保存した|作った)"
+    r"(?:書いた|書きました|書き出した|書き込んだ|作成した|作成しました"
+    r"|生成した|生成しました|保存した|保存しました|作った|作りました"
+    r"|出力した|出力しました|配置した|配置しました)"
     r"(?!い|たい|ら|り|ほうが|方が|べき|だけ|もの|そう)"
     r"|実在(?:を)?確認|確認済み|ls\s*で.*確認|stat\s*で.*確認"
     r"|\bwrote\b|\bcreated\b|\bsaved\b|\bgenerated the file\b|\bverified\b.*\bfile\b",
     re.IGNORECASE,
+)
+
+_ABSENCE_RE = re.compile(
+    r"存在しない|存在せず|見つから|不在|なかった|ありません|消えて|削除"
+    r"|does not exist|doesn'?t exist|not found|no such|absent|missing"
+    r"|never (?:written|created)",
+    re.IGNORECASE,
+)
+
+_SHELL_CMD_TOKENS = frozenset(
+    {
+        "ls",
+        "cat",
+        "stat",
+        "grep",
+        "rg",
+        "ag",
+        "fd",
+        "head",
+        "tail",
+        "sed",
+        "awk",
+        "find",
+        "cp",
+        "mv",
+        "rm",
+        "echo",
+        "touch",
+        "mkdir",
+        "chmod",
+        "diff",
+        "wc",
+        "sort",
+        "uniq",
+        "jq",
+        "bat",
+        "less",
+        "more",
+        "tree",
+        "open",
+        "git",
+        "python3",
+        "node",
+        "cd",
+    }
 )
 
 _BACKTICK_PATH_RE = re.compile(r"`([^`\n]+)`")
@@ -1102,8 +1149,12 @@ def _normalize_claim_path(raw: str) -> str | None:
     p = raw.strip().strip("'\"() 　")
     if "/" not in p or not p:
         return None
-    if re.search(r"\s", p) or "://" in p or "<" in p or ">" in p:
+    if "://" in p or "<" in p or ">" in p:
         return None
+    if re.search(r"\s", p):
+        first = p.split()[0].lstrip("$")
+        if " -" in p or first in _SHELL_CMD_TOKENS:
+            return None
     expanded = os.path.expanduser(p)
     if not os.path.isabs(expanded):
         expanded = os.path.join(os.getcwd(), expanded)
@@ -1166,6 +1217,7 @@ def _find_unbacked_claimed_paths(text: str, written: set[str]) -> list[str]:
     """Paths claimed (near a claim verb) but absent on disk AND never written."""
     paras = re.split(r"\n\s*\n", text)
     has_verb = [bool(_CLAIM_VERB_RE.search(p)) for p in paras]
+    has_absence = [bool(_ABSENCE_RE.search(p)) for p in paras]
 
     flagged: list[str] = []
     seen: set[str] = set()
@@ -1176,6 +1228,13 @@ def _find_unbacked_claimed_paths(text: str, written: set[str]) -> list[str]:
             or (i + 1 < len(paras) and has_verb[i + 1])
         )
         if not near_claim:
+            continue
+        near_absence = (
+            has_absence[i]
+            or (i > 0 and has_absence[i - 1])
+            or (i + 1 < len(paras) and has_absence[i + 1])
+        )
+        if near_absence:
             continue
         candidates = [m.group(1) for m in _BACKTICK_PATH_RE.finditer(para)]
         candidates += [m.group(1) for m in _BARE_PATH_RE.finditer(para)]

--- a/.config/claude/scripts/policy/completion-gate.py
+++ b/.config/claude/scripts/policy/completion-gate.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -1071,9 +1072,186 @@ def _check_clean_state() -> str | None:
         return None
 
 
+_CLAIM_GATE_MARKER_DIR = os.path.join(
+    os.environ.get(
+        "CLAUDE_SESSION_STATE_DIR",
+        os.path.join(os.environ.get("HOME", ""), ".claude", "session-state"),
+    ),
+    "claim-gate",
+)
+
+_CLAIM_VERB_RE = re.compile(
+    r"(?:書いた|書き出した|書き込んだ|作成した|作成しました|生成した|保存した|作った)"
+    r"(?!い|たい|ら|り|ほうが|方が|べき|だけ|もの|そう)"
+    r"|実在(?:を)?確認|確認済み|ls\s*で.*確認|stat\s*で.*確認"
+    r"|\bwrote\b|\bcreated\b|\bsaved\b|\bgenerated the file\b|\bverified\b.*\bfile\b",
+    re.IGNORECASE,
+)
+
+_BACKTICK_PATH_RE = re.compile(r"`([^`\n]+)`")
+_BARE_PATH_RE = re.compile(r"(?<![\w`:/])((?:/|~/)[\w./\-]+\.\w{1,8})")
+_TRANSCRIPT_TAIL_BYTES = 262144
+
+
+def _normalize_claim_path(raw: str) -> str | None:
+    """Normalize a mentioned path to an abspath; None if it is not path-like.
+
+    Rejects backticked commands (`ls -la /x`, `stat <path>`), URLs, and
+    placeholders — these share the path surface but are not file claims.
+    """
+    p = raw.strip().strip("'\"() 　")
+    if "/" not in p or not p:
+        return None
+    if re.search(r"\s", p) or "://" in p or "<" in p or ">" in p:
+        return None
+    expanded = os.path.expanduser(p)
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(os.getcwd(), expanded)
+    return os.path.normpath(expanded)
+
+
+def _parse_transcript_for_claims(transcript_path: str) -> tuple[set[str], str]:
+    """Return (paths written via Write tool_use, text of the last assistant turn).
+
+    Only the final assistant turn's text is kept — that is where a wrap-up
+    completion claim lives — which bounds false positives from earlier mentions.
+    """
+    try:
+        with open(transcript_path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - _TRANSCRIPT_TAIL_BYTES))
+            blob = fh.read()
+    except OSError:
+        return set(), ""
+
+    lines = blob.decode("utf-8", errors="replace").split("\n")
+    if size > _TRANSCRIPT_TAIL_BYTES and lines:
+        lines = lines[1:]
+
+    written: set[str] = set()
+    last_assistant = ""
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        msg = entry.get("message")
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        texts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "tool_use" and block.get("name") in ("Write", "NotebookEdit"):
+                fp = (block.get("input") or {}).get("file_path")
+                norm = _normalize_claim_path(fp) if isinstance(fp, str) else None
+                if norm:
+                    written.add(norm)
+            elif btype == "text" and isinstance(block.get("text"), str):
+                texts.append(block["text"])
+        if texts:
+            last_assistant = "\n".join(texts)
+    return written, last_assistant
+
+
+def _find_unbacked_claimed_paths(text: str, written: set[str]) -> list[str]:
+    """Paths claimed (near a claim verb) but absent on disk AND never written."""
+    paras = re.split(r"\n\s*\n", text)
+    has_verb = [bool(_CLAIM_VERB_RE.search(p)) for p in paras]
+
+    flagged: list[str] = []
+    seen: set[str] = set()
+    for i, para in enumerate(paras):
+        near_claim = (
+            has_verb[i]
+            or (i > 0 and has_verb[i - 1])
+            or (i + 1 < len(paras) and has_verb[i + 1])
+        )
+        if not near_claim:
+            continue
+        candidates = [m.group(1) for m in _BACKTICK_PATH_RE.finditer(para)]
+        candidates += [m.group(1) for m in _BARE_PATH_RE.finditer(para)]
+        for raw in candidates:
+            norm = _normalize_claim_path(raw)
+            if not norm or norm in seen:
+                continue
+            if os.path.exists(norm) or norm in written:
+                continue
+            seen.add(norm)
+            flagged.append(norm)
+    return flagged
+
+
+def _check_fabricated_claims(data: dict) -> dict | None:
+    """Block stop once if the final message claims file writes that never happened."""
+    transcript_path = data.get("transcript_path") if isinstance(data, dict) else None
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return None
+
+    written, last_text = _parse_transcript_for_claims(transcript_path)
+    if not last_text or not _CLAIM_VERB_RE.search(last_text):
+        return None
+
+    missing = _find_unbacked_claimed_paths(last_text, written)
+    if not missing:
+        return None
+
+    shown = "\n".join(f"  - {p}" for p in missing[:8])
+    extra = f"\n  ...他 {len(missing) - 8} 件" if len(missing) > 8 else ""
+    body = (
+        "[Claim Verification Gate] 完了主張がツール実行と一致しません。\n"
+        "最終メッセージで「書いた / 作成した / 確認済み」と述べているパスのうち、"
+        "ディスクに存在せず Write も実行されていないものがあります:\n"
+        f"{shown}{extra}\n\n"
+    )
+
+    session_id = str(data.get("session_id", "nosid"))
+    marker = os.path.join(_CLAIM_GATE_MARKER_DIR, f"blocked-{session_id}")
+    if os.path.exists(marker):
+        return None
+
+    try:
+        os.makedirs(_CLAIM_GATE_MARKER_DIR, exist_ok=True)
+        with open(marker, "w", encoding="utf-8") as fh:
+            fh.write("1")
+    except OSError as exc:
+        print(f"[completion-gate] claim marker write failed: {exc}", file=sys.stderr)
+        return None
+
+    return {
+        "decision": "block",
+        "reason": body
+        + (
+            "対応: (1) 実際に Write で作成する、または "
+            "(2) `stat <path>` で不在を確認し主張を訂正してから停止する。\n"
+            "ツール出力テキストの成功表示・exit code を証拠にしないこと。"
+        ),
+    }
+
+
 def main() -> None:
     if os.environ.get("CLAUDE_SKIP_TEST_GATE") == "1":
         return
+
+    hook_data: dict = {}
+    if not sys.stdin.isatty():
+        try:
+            hook_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, EOFError, ValueError):
+            hook_data = {}
+    if hook_data:
+        claim_result = _check_fabricated_claims(hook_data)
+        if claim_result is not None:
+            json.dump(claim_result, sys.stdout)
+            return
 
     retries = _get_retry_count()
 

--- a/.config/claude/scripts/tests/test_completion_gate_claims.py
+++ b/.config/claude/scripts/tests/test_completion_gate_claims.py
@@ -1,0 +1,152 @@
+"""Tests for completion-gate.py fabricated completion-claim gate.
+
+Regression for the 2026-06-28 incident: a session claimed it wrote and
+ls-verified a research doc that was never written (no Write tool_use, file
+absent on disk). The gate must block that, while leaving truthful claims and
+backed writes alone.
+"""
+
+import json
+import sys
+from importlib import import_module
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "policy"))
+
+gate = import_module("completion-gate")
+
+
+def _assistant_text(text: str) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+        }
+    )
+
+
+def _write_tool_use(file_path: str) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Write",
+                        "input": {"file_path": file_path, "content": "x"},
+                    }
+                ],
+            },
+        }
+    )
+
+
+def _transcript(tmp_path: Path, *lines: str) -> Path:
+    p = tmp_path / "transcript.jsonl"
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def _data(tmp_path: Path, transcript: Path, sid: str = "s1") -> dict:
+    gate._CLAIM_GATE_MARKER_DIR = str(tmp_path / "claim-gate")
+    return {"transcript_path": str(transcript), "session_id": sid}
+
+
+def test_blocks_fabricated_write_claim(tmp_path):
+    missing = tmp_path / "2026-06-28-never-written.md"
+    text = (
+        f"ファイルはここに書いた:\n\n`{missing}`\n\n(`ls` で実在確認済み: 6747 バイト)"
+    )
+    tr = _transcript(tmp_path, _assistant_text("作業開始"), _assistant_text(text))
+    result = gate._check_fabricated_claims(_data(tmp_path, tr))
+    assert result is not None
+    assert result.get("decision") == "block"
+    assert str(missing) in result["reason"]
+
+
+def test_allows_when_file_exists(tmp_path):
+    real = tmp_path / "real.md"
+    real.write_text("done", encoding="utf-8")
+    text = f"分析を `{real}` に書き出した。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None
+
+
+def test_allows_when_write_tool_was_called(tmp_path):
+    target = tmp_path / "via-write.md"
+    text = f"`{target}` を作成した。"
+    tr = _transcript(
+        tmp_path,
+        _write_tool_use(str(target)),
+        _assistant_text(text),
+    )
+    assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None
+
+
+def test_ignores_future_tense_intent(tmp_path):
+    planned = tmp_path / "will-create.md"
+    text = f"次に `{planned}` を作成します。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None
+
+
+def test_ignores_path_without_claim_verb(tmp_path):
+    missing = tmp_path / "mentioned.md"
+    text = f"参考までに `{missing}` というパス命名が候補です。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None
+
+
+def test_ignores_desiderative_and_conditional_verbs(tmp_path):
+    planned = tmp_path / "suggestion.md"
+    for phrase in ("作成したほうがいい", "作成したい", "作成したら便利"):
+        text = f"このファイルも{phrase}: `{planned}`"
+        tr = _transcript(tmp_path, _assistant_text(text))
+        assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None, phrase
+
+
+def test_ignores_backticked_command(tmp_path):
+    missing = tmp_path / "x.md"
+    text = f"`{missing}` を作成した。確認は `stat {missing}` と `ls -la /tmp/x` で。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    result = gate._check_fabricated_claims(_data(tmp_path, tr))
+    assert result is not None and result.get("decision") == "block"
+    flagged_section = result["reason"].split("対応:")[0]
+    assert str(missing) in flagged_section
+    assert "stat " not in flagged_section
+    assert "ls -la" not in flagged_section
+
+
+def test_ignores_url(tmp_path):
+    text = "ドキュメントは `https://example.com/guide/page.html` に作成した。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None
+
+
+def test_second_block_allows_to_bound_loop(tmp_path):
+    missing = tmp_path / "ghost.md"
+    text = f"`{missing}` を作成した。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    data = _data(tmp_path, tr)
+    first = gate._check_fabricated_claims(data)
+    assert first.get("decision") == "block"
+    assert gate._check_fabricated_claims(data) is None
+
+
+def test_marker_write_failure_fails_open(tmp_path, monkeypatch):
+    missing = tmp_path / "ghost.md"
+    text = f"`{missing}` を作成した。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    data = _data(tmp_path, tr)
+
+    def _boom(*_a, **_k):
+        raise OSError("read-only")
+
+    monkeypatch.setattr(gate.os, "makedirs", _boom)
+    assert gate._check_fabricated_claims(data) is None

--- a/.config/claude/scripts/tests/test_completion_gate_claims.py
+++ b/.config/claude/scripts/tests/test_completion_gate_claims.py
@@ -129,6 +129,34 @@ def test_ignores_url(tmp_path):
     assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None
 
 
+def test_ignores_absence_confirmation(tmp_path):
+    missing = tmp_path / "phantom.md"
+    for phrase in (
+        "は存在しないことを確認済みです",
+        "は見つからなかった",
+        " does not exist",
+    ):
+        text = f"`{missing}`{phrase}。"
+        tr = _transcript(tmp_path, _assistant_text(text))
+        assert gate._check_fabricated_claims(_data(tmp_path, tr)) is None, phrase
+
+
+def test_blocks_fabricated_path_with_space(tmp_path):
+    missing = tmp_path / "My Report.md"
+    text = f"`{missing}` を作成した。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    result = gate._check_fabricated_claims(_data(tmp_path, tr))
+    assert result is not None and result.get("decision") == "block"
+
+
+def test_blocks_polite_past_verb(tmp_path):
+    missing = tmp_path / "polite.md"
+    text = f"`{missing}` を保存しました。"
+    tr = _transcript(tmp_path, _assistant_text(text))
+    result = gate._check_fabricated_claims(_data(tmp_path, tr))
+    assert result is not None and result.get("decision") == "block"
+
+
 def test_second_block_allows_to_bound_loop(tmp_path):
     missing = tmp_path / "ghost.md"
     text = f"`{missing}` を作成した。"


### PR DESCRIPTION
## 背景

2026-06-28、あるセッションが research doc を「書いた・`ls` で実在確認済み (6747 バイト)」と報告したが、実際には **Write tool_use は一度も呼ばれず、ファイルもディスクに存在しなかった**。完了報告そのものがモデルの幻覚だった。`ls 確認` の検証ステップまで捏造されていた。

instruction レベルの対策 (`feedback_tool_output_verify_mutations`, 2026-06-25「決定的コマンドで検証しろ」) は既に memory にあり、それでも 3 日で再発した。原則どおり **mechanism に寄せる**。

## 何をするか

Stop hook の `completion-gate.py` に判定を 1 本追加する (settings.json は変更なし — 既に Stop に配線済み)。

最終 assistant メッセージが「書いた / 作成した / 確認済み」系の主張を含み、近接段落で言及されたパスが **ディスクに存在せず かつ Write tool_use もされていない** 場合に `decision: block` し、再検証を促す。

設計の要点:
- 最終 assistant turn のみ走査 (過去 turn の言及で誤検知しない)
- 過去形の作成/検証動詞のみ。未来形・desiderative/conditional (`作成します`/`作成したい`/`作成したほうがいい`) は否定先読みで除外
- 不在報告 (`/x.md は存在しないことを確認済み`) は `_ABSENCE_RE` で除外
- コマンド (`stat <path>`/`ls -la /x`)・URL・placeholder は path 正規化で除外
- marker で 1 セッション 1 block、marker 書き込み失敗時は **fail-open** (このゲートのバグで Stop を阻害しないことを最優先)
- byte-tail 読みで長大 transcript の O(filesize) 走査を回避

## レビュー (ハーネス変更の標準ゲート)

- **code-reviewer (opus)**: BLOCK 1 (marker fail-open) + false-positive 2 を指摘 → 全件反映
- **Codex Review Gate (gpt-5.5, effort high)**: **PASS**。永久 Stop 不能経路なし・既存 Ralph/test/retry gate 非破壊を確認。IMPORTANT 3 (不在報告誤 block / 空白パス / 丁寧形動詞) を反映

## テスト

`scripts/tests/test_completion_gate_claims.py` を新規追加 (13 ケース: 捏造 block / 真の主張 allow / Write 済み allow / 未来形・不在報告・コマンド・URL 除外 / ループ封じ / fail-open)。**scripts/tests 全体 297 passed**、ruff clean、end-to-end smoke で実捏造の block を確認。

## 既知の限界 (非対応, YAGNI)

backtick で囲まない bare 相対パス (`docs/report.md を作成した`) はすり抜ける。backtick 付き相対パスは検出可能で、Claude はパスを backtick 化するのが通常のため実用上の穴は小さい。bare 相対の拡張は false-positive リスクが大きいので見送る。

https://claude.ai/code/session_01XLh4rrRXxosBeaVvVhqagD
